### PR TITLE
fix: READMEのフレームワーク・ライブラリバージョンを実装に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,21 @@
 
 | Name         | Version | Usage        |
 |--------------|---------|--------------|
-| Scala        | 2.12.20 | -            |
-| Scalatra     | 3.1.x   | All of them. |
+| Scala        | 3.3.7   | -            |
+| Scalatra     | 3.1.2   | All of them. |
+| Jetty        | 12.1.7  | Web Server   |
 | Servlet API  | 6.1.0   | Web API      |
-| slf4j        | 2.8.x   | Logging      |
-| logback      | 1.5.x   | Logging      |
-| Flyway       | 9.22.3  | Migration    |
-| Slick        | 3.6.x   | ORM          |
-| PostgresSQL  | 42.7.x  | DB           |
+| slf4j        | 2.0.17  | Logging      |
+| logback      | 1.5.32  | Logging      |
+| Flyway       | 12.2.0  | Migration    |
+| Slick        | 3.6.1   | ORM          |
+| PostgreSQL   | 42.7.10 | DB           |
 | Google Guice | 7.0.0   | DI           |
-| Scala Cache  | 0.28.0  | Cache        |
-| sttp client  | 4.0.9   | HTTP Client  |
-| jXls         | 3.0.0   | Reporting |
+| Jedis        | 7.4.0   | Cache(Redis) |
+| sttp client  | 4.0.19  | HTTP Client  |
+| jXls         | 3.1.0   | Reporting    |
+| AWS SDK      | 2.42.22 | Storage(S3)  |
+| Auth0        | 3.3.0   | JWT          |
 
 ## Features (including not implemented yet)
 - [ ] Output reporting.


### PR DESCRIPTION
Scala 3移行後の実態に合わせてバージョン情報を更新し、未使用のScala Cacheを削除、
Jedis/Jetty/AWS SDK/Auth0を追加。

## 概要

<!-- このPRで何を変更したか簡潔に記述 -->


## 変更内容

<!-- 具体的な変更内容をリストアップ -->

-
-

## 関連Issue

<!-- 関連するIssue番号（例: #123） -->


## Claude レビュー観点（PR固有）

<!--
  以下のマーカー内に、このPRで特に重点的にレビューしてほしい観点を記述してください。
  マーカーを削除しなければ、Claude が自動的に読み取ってレビューに反映します。
  不要な場合はマーカーごと削除するか、空のままにしてください。
-->

<!-- REVIEW_FOCUS -->
<!-- 例:
- 今回新たに導入した認証ミドルウェアが既存のルーティングに影響していないか
- レスポンスのページネーション実装が仕様通りか（1ページ50件、cursor方式）
- エラー時のリトライロジック（最大3回、exponential backoff）の正しさ
-->
<!-- /REVIEW_FOCUS -->

## スクリーンショット（任意）

<!-- UI変更がある場合はスクリーンショットを貼付 -->


## チェックリスト

- [ ] ローカルで動作確認済み
- [ ] テストを追加・更新済み
- [ ] ドキュメントを更新済み（必要な場合）
