### PR TITLE
chore: .gitignore に Claude Code のローカル設定ファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ project/metals.sbt
 
 # paulp script
 /.lib/
+
+# Claude Code
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- `.claude/settings.local.json`（個人環境固有の設定ファイル）を `.gitignore` に追加
- `.claude/commands/` などチームで共有可能なファイルはコミット対象として残すため、`.claude/` 全体ではなく `settings.local.json` のみを除外

## Test plan
- [ ] `.claude/settings.local.json` が `git status` に表示されないことを確認
- [ ] `.claude/commands/` 配下のファイルは引き続きトラッキング可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)