### PR TITLE
fix: infrastructure 層のバグ・脆弱性を修正 (MUST)

### DIFF
--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/cache/CacheKey.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/cache/CacheKey.scala
@@ -2,7 +2,7 @@ package jp.ijufumi.openreports.infrastructure.cache
 
 sealed trait CacheKey {
   def key(args: String*): String = {
-    s"${getClass.getName}-${args.mkString}"
+    s"${getClass.getName}-${args.mkString(":")}"
   }
 }
 

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/external/google/impl/GoogleRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/external/google/impl/GoogleRepositoryImpl.scala
@@ -41,8 +41,6 @@ class GoogleRepositoryImpl @Inject() (backend: WebSocketSyncBackend = HttpClient
       Strings.convertToBase64(s"${Config.GOOGLE_CLIENT_ID}:${Config.GOOGLE_CLIENT_SECRET}")
 
     val body: Map[String, String] = Map(
-      "client_id" -> Config.GOOGLE_CLIENT_ID,
-      "client_secret" -> Config.GOOGLE_CLIENT_SECRET,
       "grant_type" -> "authorization_code",
       "code" -> code,
       "redirect_uri" -> REDIRECT_URL,

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/DataSourceRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/DataSourceRepositoryImpl.scala
@@ -14,7 +14,7 @@ class DataSourceRepositoryImpl extends DataSourceRepository {
       .filter(_.id === id)
       .filter(_.workspaceId === workspaceId)
     val dataSources = Await.result(db.run(getDataSources.result), queryTimeout)
-    Some(dataSources.head)
+    dataSources.headOption
   }
 
   override def getAll(db: Database, workspaceId: String): Seq[DataSource] = {

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/WorkspaceMemberRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/WorkspaceMemberRepositoryImpl.scala
@@ -76,8 +76,9 @@ class WorkspaceMemberRepositoryImpl extends WorkspaceMemberRepository {
   }
 
   override def delete(db: Database, workspaceId: String, memberId: String): Unit = {
-    val getById = workspaceMemberQuery
+    val target = workspaceMemberQuery
       .filter(_.workspaceId === workspaceId)
-    Await.result(db.run(getById.delete.withPinnedSession), queryTimeout)
+      .filter(_.memberId === memberId)
+    Await.result(db.run(target.delete.withPinnedSession), queryTimeout)
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/storage/local/impl/LocalFileRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/storage/local/impl/LocalFileRepositoryImpl.scala
@@ -10,11 +10,11 @@ class LocalFileRepositoryImpl @Inject() (implicit
     templateRootPath: String = Config.TEMPLATE_ROOT_PATH,
 ) extends LocalFileRepository {
   override def get(workspaceId: String, key: String): Path = {
-    FileSystems.getDefault.getPath(templateRootPath, workspaceId, key)
+    resolveSafePath(workspaceId, key)
   }
 
   override def create(workspaceId: String, key: String, file: Path): Unit = {
-    val fullPath = FileSystems.getDefault.getPath(templateRootPath, workspaceId, key)
+    val fullPath = resolveSafePath(workspaceId, key)
     Files.createDirectories(fullPath.getParent)
     Files.copy(file, fullPath)
   }
@@ -22,4 +22,15 @@ class LocalFileRepositoryImpl @Inject() (implicit
   override def delete(workspaceId: String, key: String): Unit = ???
 
   override def url(workspaceId: String, key: String): String = ???
+
+  private def resolveSafePath(workspaceId: String, key: String): Path = {
+    val root = FileSystems.getDefault.getPath(templateRootPath).toAbsolutePath.normalize()
+    val resolved = root.resolve(workspaceId).resolve(key).normalize()
+    if (!resolved.startsWith(root)) {
+      throw new IllegalArgumentException(
+        s"path traversal detected: workspaceId=$workspaceId, key=$key",
+      )
+    }
+    resolved
+  }
 }

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/storage/local/impl/LocalSeedFileRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/storage/local/impl/LocalSeedFileRepositoryImpl.scala
@@ -3,11 +3,19 @@ package jp.ijufumi.openreports.infrastructure.storage.local.impl
 import jp.ijufumi.openreports.configs.Config
 import jp.ijufumi.openreports.infrastructure.storage.local.LocalSeedFileRepository
 
-import java.nio.file.{Files, FileSystems, Path}
+import java.nio.file.{FileSystems, Path}
 
 class LocalSeedFileRepositoryImpl extends LocalSeedFileRepository {
   override def get(workspaceId: String, key: String): Path = {
-    FileSystems.getDefault.getPath(Config.SEED_TEMPLATE_ROOT_PATH, key)
+    val root = FileSystems.getDefault
+      .getPath(Config.SEED_TEMPLATE_ROOT_PATH)
+      .toAbsolutePath
+      .normalize()
+    val resolved = root.resolve(key).normalize()
+    if (!resolved.startsWith(root)) {
+      throw new IllegalArgumentException(s"path traversal detected: key=$key")
+    }
+    resolved
   }
 
   override def create(workspaceId: String, key: String, file: Path): Unit = {}

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/storage/s3/impl/AwsS3RepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/storage/s3/impl/AwsS3RepositoryImpl.scala
@@ -54,10 +54,11 @@ class AwsS3RepositoryImpl @Inject() (
     val storage = this.getStorage(workspaceId)
     val request = GetObjectRequest.builder().bucket(storage.s3BucketName).key(key).build()
     val file = Files.createTempFile("", ".tmp")
-    val response = Using(s3ClientFactory.createClient(storage)) { client =>
-      client.getObject(request)
-    }.get
-    Files.copy(response, file)
+    Using.resource(s3ClientFactory.createClient(storage)) { client =>
+      Using.resource(client.getObject(request)) { response =>
+        Files.copy(response, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+      }
+    }
     file
   }
 

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/cache/CacheKeySpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/cache/CacheKeySpec.scala
@@ -19,7 +19,14 @@ class CacheKeySpec extends AnyFlatSpec with Matchers {
   it should "generate key with multiple arguments" in {
     val key = CacheKeys.GoogleAuthState.key("state1", "state2")
     key should include("jp.ijufumi.openreports.infrastructure.cache.CacheKeys$GoogleAuthState$")
-    key should include("state1state2")
+    key should include("state1:state2")
+  }
+
+  it should "generate distinct keys for argument sequences that share the same concatenation" in {
+    val key1 = CacheKeys.ApiToken.key("ab", "c")
+    val key2 = CacheKeys.ApiToken.key("a", "bc")
+
+    key1 should not equal key2
   }
 
   it should "generate unique keys for different cache types" in {

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/DataSourceRepositoryImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/DataSourceRepositoryImplSpec.scala
@@ -129,6 +129,12 @@ class DataSourceRepositoryImplSpec
     result.get.workspaceId should equal(workspaceId1)
   }
 
+  it should "return None when data source doesn't exist" in {
+    val result = repository.getById(db, IDs.ulid(), IDs.ulid())
+
+    result should be(None)
+  }
+
   "getAll" should "return all data sources for workspace" in {
     val workspaceId = IDs.ulid()
     val driverType = createTestDriverType()

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/WorkspaceMemberRepositoryImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/WorkspaceMemberRepositoryImplSpec.scala
@@ -232,6 +232,21 @@ class WorkspaceMemberRepositoryImplSpec
     repository.getById(db, workspaceId2, member.id) should be(defined)
   }
 
+  it should "only delete the specified member within a workspace" in {
+    val workspaceId = IDs.ulid()
+    val member1 = createTestMember()
+    val member2 = createTestMember()
+
+    repository.register(db, createTestWorkspaceMember(workspaceId, member1.id))
+    repository.register(db, createTestWorkspaceMember(workspaceId, member2.id))
+
+    repository.delete(db, workspaceId, member1.id)
+
+    repository.getById(db, workspaceId, member1.id) should be(None)
+    repository.getById(db, workspaceId, member2.id) should be(defined)
+    repository.gets(db, workspaceId) should have size 1
+  }
+
   "WorkspaceMemberRepository" should "handle multiple roles" in {
     val workspaceId = IDs.ulid()
     val member1 = createTestMember()

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/storage/local/impl/LocalFileRepositoryImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/storage/local/impl/LocalFileRepositoryImplSpec.scala
@@ -102,6 +102,36 @@ class LocalFileRepositoryImplSpec
     Files.deleteIfExists(sourceFile)
   }
 
+  "get" should "reject path traversal in key" in {
+    val templateRootPath = tempDir.toString
+    val repository = new LocalFileRepositoryImpl()(templateRootPath = templateRootPath)
+
+    an[IllegalArgumentException] should be thrownBy
+      repository.get(testWorkspaceId, "../../../etc/passwd")
+  }
+
+  it should "reject path traversal in workspaceId" in {
+    val templateRootPath = tempDir.toString
+    val repository = new LocalFileRepositoryImpl()(templateRootPath = templateRootPath)
+
+    an[IllegalArgumentException] should be thrownBy
+      repository.get("../escape", "file.txt")
+  }
+
+  "create" should "reject path traversal in key" in {
+    val templateRootPath = tempDir.toString
+    val repository = new LocalFileRepositoryImpl()(templateRootPath = templateRootPath)
+    val sourceFile = Files.createTempFile(tempDir, "src", ".txt")
+    Files.write(sourceFile, "x".getBytes)
+
+    try {
+      an[IllegalArgumentException] should be thrownBy
+        repository.create(testWorkspaceId, "../../escape.txt", sourceFile)
+    } finally {
+      Files.deleteIfExists(sourceFile)
+    }
+  }
+
   it should "overwrite existing file" in {
     val templateRootPath = tempDir.toString
 

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/storage/s3/impl/AwsS3RepositoryImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/storage/s3/impl/AwsS3RepositoryImplSpec.scala
@@ -70,15 +70,18 @@ class AwsS3RepositoryImplSpec extends AnyFlatSpec with Matchers with MockitoSuga
 
     val repository = new AwsS3RepositoryImpl(db, storageRepository, s3ClientFactory)
 
-    // The current implementation tries to copy from the response stream
-    // We need to handle the stream closing properly
-    assertThrows[Exception] {
-      // This will fail because we're mocking, but it tests that the method is called
-      repository.get(workspaceId, key)
+    val resultPath = repository.get(workspaceId, key)
+
+    try {
+      Files.exists(resultPath) should be(true)
+      new String(Files.readAllBytes(resultPath)) should equal(testContent)
+    } finally {
+      Files.deleteIfExists(resultPath)
     }
 
     verify(storageRepository).gets(db, workspaceId)
     verify(s3ClientFactory).createClient(storage)
+    verify(s3Client).close()
   }
 
   "create" should "upload file to S3 bucket" in {


### PR DESCRIPTION
## Summary

infrastructure 配下のコードレビューで検出された MUST レベルの指摘事項 6 件を修正します。バグ・セキュリティ脆弱性が含まれるため優先対応です。

### 修正内容

| # | ファイル | 内容 |
|---|---------|---------|
| 1 | `WorkspaceMemberRepositoryImpl.delete` | `memberId` フィルタが抜けており指定ワークスペースの**全メンバーが削除**される重大バグを修正 |
| 2 | `DataSourceRepositoryImpl.getById` | `Option[DataSource]` 戻り値型なのに `head` を直接使っており、空の場合 `NoSuchElementException` を投げる挙動を `headOption` に修正 |
| 3 | `LocalFileRepositoryImpl` / `LocalSeedFileRepositoryImpl` | `workspaceId`・`key` 経由のパストラバーサル脆弱性 (`../../etc/passwd` 等) を `normalize() + startsWith` で防御 |
| 4 | `AwsS3RepositoryImpl.get` | `Using` ブロックを抜けて S3Client が close された**後**にストリームを読み込む順序バグ + `ResponseInputStream` リークを `Using.resource` のネストで修正 |
| 5 | `GoogleRepositoryImpl.fetchToken` | Basic 認証ヘッダとフォーム body の両方で `client_secret` を送信していたのを Basic ヘッダのみに統一 (RFC 6749 §2.3.1) |
| 6 | `CacheKey.key` | `args.mkString` で区切り文字なし連結していたためキー衝突が起こり得る (`("ab","c")` と `("a","bc")` が同一キー) ので `":"` 区切りに変更 |

### テスト追加

- `WorkspaceMemberRepositoryImplSpec`: 同一 workspace 内の他メンバーが残ることを保証するテストを追加
- `DataSourceRepositoryImplSpec`: `getById` の None ケースを追加
- `LocalFileRepositoryImplSpec`: パストラバーサル拒否を 3 ケース追加
- `AwsS3RepositoryImplSpec`: `get` テストを成功検証 + `close()` 検証に書き換え
- `CacheKeySpec`: 区切り文字反映と衝突回避の保証テストを追加

## Test plan

- [x] `sbt compile` 成功
- [x] `sbt test` 全 610 件パス
- [ ] CI green
- [ ] レビュアー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)