### PR TITLE
refactor: infrastructure 層のパフォーマンス・保守性を改善 (SHOULD)

### DIFF
--- a/src/main/scala/jp/ijufumi/openreports/configs/Config.scala
+++ b/src/main/scala/jp/ijufumi/openreports/configs/Config.scala
@@ -32,6 +32,10 @@ object Config {
   val DB_USER: String = getEnvValue("DB_USER", "postgres")
   val DB_PASSWORD: String = getEnvValue("DB_PASSWORD", "password")
   val DB_PORT: String = getEnvValue("DB_PORT", "5432")
+  val DB_NUM_THREADS: Int = getEnvIntValue("DB_NUM_THREADS", 5)
+  val DB_POOL_SIZE: Int = getEnvIntValue("DB_POOL_SIZE", 20)
+  val DB_KEEP_ALIVE_CONNECTION: Boolean =
+    getEnvValue("DB_KEEP_ALIVE_CONNECTION", "false").toBoolean
   // for hash
   val HASH_KEY: String = requireEnvValue("HASH_KEY")
   val ACCESS_TOKEN_EXPIRATION_SEC: Integer =

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/cache/CacheWrapper.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/cache/CacheWrapper.scala
@@ -1,77 +1,53 @@
 package jp.ijufumi.openreports.infrastructure.cache
 
 import jp.ijufumi.openreports.configs.Config
+import org.slf4j.LoggerFactory
 import redis.clients.jedis.{JedisPool, JedisPoolConfig}
 
 class CacheWrapper(
-                    pool: JedisPool = {
-                      val config = new JedisPoolConfig()
-                      config.setMaxTotal(Config.REDIS_POOL_MAX_SIZE)
-                      config.setMaxIdle(Config.REDIS_POOL_MAX_IDLE)
-                      config.setMinIdle(Config.REDIS_POOL_MIN_IDLE)
-                      config.setTestOnBorrow(true)
-                      new JedisPool(config, Config.REDIS_HOST, Config.REDIS_PORT, 3000)
-                    },
+    pool: JedisPool = {
+      val config = new JedisPoolConfig()
+      config.setMaxTotal(Config.REDIS_POOL_MAX_SIZE)
+      config.setMaxIdle(Config.REDIS_POOL_MAX_IDLE)
+      config.setMinIdle(Config.REDIS_POOL_MIN_IDLE)
+      config.setTestOnBorrow(true)
+      new JedisPool(config, Config.REDIS_HOST, Config.REDIS_PORT, 3000)
+    },
 ) {
+  private val logger = LoggerFactory.getLogger(getClass)
   private val defaultTtl = Config.CACHE_TTL_SEC
-  private val lock = new java.util.concurrent.locks.ReentrantReadWriteLock()
 
   def put(cacheKey: CacheKey, value: String, args: String*)(implicit
       ttl: Long = defaultTtl,
   ): Unit = {
-    try {
-      lock.writeLock().lock()
-      val jedis = pool.getResource
-      try {
-        val key = cacheKey.key(args*)
-        jedis.setex(key, ttl, value)
-      } finally {
-        jedis.close()
-      }
-    } catch {
-      case e: Exception =>
-        // Redis unavailable — log and continue (cache miss is acceptable)
-        org.slf4j.LoggerFactory.getLogger(getClass).warn(s"Failed to put cache key: $cacheKey", e)
-    } finally {
-      lock.writeLock().unlock()
+    withJedis(s"put $cacheKey") { jedis =>
+      jedis.setex(cacheKey.key(args*), ttl, value)
+      ()
     }
   }
 
   def get(cacheKey: CacheKey, args: String*): Option[String] = {
-    try {
-      lock.readLock().lock()
-      val jedis = pool.getResource
-      try {
-        val value = jedis.get(cacheKey.key(args*))
-        Option(value)
-      } finally {
-        jedis.close()
-      }
-    } catch {
-      case e: Exception =>
-        // Redis unavailable — log and continue (cache miss is acceptable)
-        org.slf4j.LoggerFactory.getLogger(getClass).warn(s"Failed to get cache key: $cacheKey", e)
-        None
-    } finally {
-      lock.readLock().unlock()
-    }
+    withJedis(s"get $cacheKey") { jedis =>
+      Option(jedis.get(cacheKey.key(args*)))
+    }.flatten
   }
 
   def remove(cacheKey: CacheKey, args: String*): Unit = {
+    withJedis(s"remove $cacheKey") { jedis =>
+      jedis.del(cacheKey.key(args*))
+      ()
+    }
+  }
+
+  private def withJedis[T](op: String)(f: redis.clients.jedis.Jedis => T): Option[T] = {
     try {
-      lock.writeLock().lock()
       val jedis = pool.getResource
-      try {
-        jedis.del(cacheKey.key(args*))
-      } finally {
-        jedis.close()
-      }
+      try Some(f(jedis))
+      finally jedis.close()
     } catch {
       case e: Exception =>
-        // Redis unavailable — log and continue (cache miss is acceptable)
-        org.slf4j.LoggerFactory.getLogger(getClass).warn(s"Failed to remove cache key: $cacheKey", e)
-    } finally {
-      lock.writeLock().unlock()
+        logger.warn(s"cache operation failed: $op", e)
+        None
     }
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/database/db/DatabaseFactory.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/database/db/DatabaseFactory.scala
@@ -17,9 +17,9 @@ object DatabaseFactory {
         "username" -> DB_USER,
         "password" -> DB_PASSWORD,
         "connectionPool" -> "HikariCP",
-        "numThreads" -> 5,
-        "poolSize" -> 20,
-        "keepAliveConnection" -> true,
+        "numThreads" -> DB_NUM_THREADS,
+        "poolSize" -> DB_POOL_SIZE,
+        "keepAliveConnection" -> DB_KEEP_ALIVE_CONNECTION,
       ).asJava,
     ).asJava,
   )

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/database/pool/ConnectionPool.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/database/pool/ConnectionPool.scala
@@ -1,15 +1,15 @@
 package jp.ijufumi.openreports.infrastructure.persistence.database.pool
 
-import jp.ijufumi.openreports.exceptions.NotFoundException
-import jp.ijufumi.openreports.domain.models.value.enums.JdbcDriverClasses
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.pool.HikariPool
+import jp.ijufumi.openreports.domain.models.value.enums.JdbcDriverClasses
+import jp.ijufumi.openreports.exceptions.NotFoundException
 
 import java.sql.Connection
-import scala.collection.mutable
+import java.util.concurrent.ConcurrentHashMap
 
 object ConnectionPool {
-  private val pool = mutable.Map.empty[String, HikariPool]
+  private val pools = new ConcurrentHashMap[String, HikariPool]()
 
   def newConnection(
       name: String,
@@ -19,38 +19,35 @@ object ConnectionPool {
       jdbcDriverClass: JdbcDriverClasses.JdbcDriverClass,
       maxPoolSize: Integer,
   ): Connection = {
-    this.synchronized {
-      if (has(name)) {
-        return getConnection(name)
-      }
-      val config = new HikariConfig()
-      config.setUsername(username)
-      config.setPassword(password)
-      config.setJdbcUrl(url)
-      config.setAutoCommit(false)
-      config.setMaximumPoolSize(maxPoolSize)
-      config.setDriverClassName(jdbcDriverClass.toString)
-      pool += (name -> new HikariPool(config))
-
-      getConnection(name)
-    }
+    val pool = pools.computeIfAbsent(
+      name,
+      _ => buildPool(username, password, url, jdbcDriverClass, maxPoolSize),
+    )
+    pool.getConnection()
   }
 
   def newConnection(name: String): Connection = {
-    this.synchronized {
-      if (!has(name)) {
-        throw new NotFoundException
-      }
-
-      getConnection(name)
+    val pool = pools.get(name)
+    if (pool == null) {
+      throw new NotFoundException
     }
+    pool.getConnection()
   }
 
-  private def has(name: String): Boolean = {
-    pool.contains(name)
-  }
-
-  private def getConnection(name: String): Connection = {
-    pool(name).getConnection()
+  private def buildPool(
+      username: String,
+      password: String,
+      url: String,
+      jdbcDriverClass: JdbcDriverClasses.JdbcDriverClass,
+      maxPoolSize: Integer,
+  ): HikariPool = {
+    val config = new HikariConfig()
+    config.setUsername(username)
+    config.setPassword(password)
+    config.setJdbcUrl(url)
+    config.setAutoCommit(false)
+    config.setMaximumPoolSize(maxPoolSize)
+    config.setDriverClassName(jdbcDriverClass.toString)
+    new HikariPool(config)
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportGroupReportRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportGroupReportRepositoryImpl.scala
@@ -15,12 +15,11 @@ class ReportGroupReportRepositoryImpl extends ReportGroupReportRepository {
       offset: Int = 0,
       limit: Int = -1,
   ): (Seq[ReportGroupReport], Int) = {
-    var filtered = reportGroupReportQuery.drop(0)
-    val count = Await.result(db.run(filtered.length.result), queryTimeout)
-    if (limit > 0) {
-      filtered = filtered.drop(offset).take(limit)
-    }
-    val result = Await.result(db.run(filtered.result), queryTimeout)
+    val count = Await.result(db.run(reportGroupReportQuery.length.result), queryTimeout)
+    val withOffset =
+      if (offset > 0) reportGroupReportQuery.drop(offset) else reportGroupReportQuery
+    val paged = if (limit > 0) withOffset.take(limit) else withOffset
+    val result = Await.result(db.run(paged.result), queryTimeout)
     (result, count)
   }
 
@@ -75,18 +74,18 @@ class ReportGroupReportRepositoryImpl extends ReportGroupReportRepository {
   override def delete(db: Database, id: String): Unit = {
     val getById = reportGroupReportQuery
       .filter(_.id === id)
-    Await.result(db.run(getById.delete), queryTimeout)
+    Await.result(db.run(getById.delete.withPinnedSession), queryTimeout)
   }
 
   override def deleteByReportId(db: Database, id: String): Unit = {
     val getById = reportGroupReportQuery
       .filter(_.reportId === id)
-    Await.result(db.run(getById.delete), queryTimeout)
+    Await.result(db.run(getById.delete.withPinnedSession), queryTimeout)
   }
 
   override def deleteByReportGroupId(db: Database, id: String): Unit = {
     val getById = reportGroupReportQuery
       .filter(_.reportGroupId === id)
-    Await.result(db.run(getById.delete), queryTimeout)
+    Await.result(db.run(getById.delete.withPinnedSession), queryTimeout)
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportGroupRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportGroupRepositoryImpl.scala
@@ -16,12 +16,11 @@ class ReportGroupRepositoryImpl extends ReportGroupRepository {
       offset: Int = 0,
       limit: Int = -1,
   ): (Seq[ReportGroup], Int) = {
-    var filtered = reportGroupQuery.filter(_.workspaceId === workspaceId)
+    val filtered = reportGroupQuery.filter(_.workspaceId === workspaceId)
     val count = Await.result(db.run(filtered.length.result), queryTimeout)
-    if (limit > 0) {
-      filtered = filtered.drop(offset).take(limit)
-    }
-    val result = Await.result(db.run(filtered.result), queryTimeout)
+    val withOffset = if (offset > 0) filtered.drop(offset) else filtered
+    val paged = if (limit > 0) withOffset.take(limit) else withOffset
+    val result = Await.result(db.run(paged.result), queryTimeout)
     (result, count)
   }
 
@@ -52,6 +51,6 @@ class ReportGroupRepositoryImpl extends ReportGroupRepository {
     val getById = reportGroupQuery
       .filter(_.workspaceId === workspaceId)
       .filter(_.id === id)
-    Await.result(db.run(getById.delete), queryTimeout)
+    Await.result(db.run(getById.delete.withPinnedSession), queryTimeout)
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportParameterRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportParameterRepositoryImpl.scala
@@ -16,12 +16,11 @@ class ReportParameterRepositoryImpl extends ReportParameterRepository {
       offset: Int = 0,
       limit: Int = -1,
   ): (Seq[ReportParameter], Int) = {
-    var filtered = reportParameterQuery.filter(_.workspaceId === workspaceId)
+    val filtered = reportParameterQuery.filter(_.workspaceId === workspaceId)
     val count = Await.result(db.run(filtered.length.result), queryTimeout)
-    if (limit > 0) {
-      filtered = filtered.drop(offset).take(limit)
-    }
-    val result = Await.result(db.run(filtered.result), queryTimeout)
+    val withOffset = if (offset > 0) filtered.drop(offset) else filtered
+    val paged = if (limit > 0) withOffset.take(limit) else withOffset
+    val result = Await.result(db.run(paged.result), queryTimeout)
     (result, count)
   }
 
@@ -52,6 +51,6 @@ class ReportParameterRepositoryImpl extends ReportParameterRepository {
     val getById = reportParameterQuery
       .filter(_.workspaceId === workspaceId)
       .filter(_.id === id)
-    Await.result(db.run(getById.delete), queryTimeout)
+    Await.result(db.run(getById.delete.withPinnedSession), queryTimeout)
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportReportParameterRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportReportParameterRepositoryImpl.scala
@@ -16,17 +16,14 @@ class ReportReportParameterRepositoryImpl extends ReportReportParameterRepositor
       offset: Int = 0,
       limit: Int = -1,
   ): (Seq[ReportReportParameter], Int) = {
-    var filtered = reportReportParameterQuery.drop(0)
-    val count = Await.result(db.run(filtered.length.result), queryTimeout)
-    if (limit > 0) {
-      filtered = filtered.drop(offset).take(limit)
-    }
-    (
-      Await
-        .result(db.run(filtered.result), queryTimeout)
-        .map(r => ReportReportParameterConverter.toDomain(r)),
-      count,
-    )
+    val count = Await.result(db.run(reportReportParameterQuery.length.result), queryTimeout)
+    val withOffset =
+      if (offset > 0) reportReportParameterQuery.drop(offset) else reportReportParameterQuery
+    val paged = if (limit > 0) withOffset.take(limit) else withOffset
+    val rows = Await
+      .result(db.run(paged.result), queryTimeout)
+      .map(ReportReportParameterConverter.toDomain)
+    (rows, count)
   }
 
   override def getById(db: Database, id: String): Option[ReportReportParameter] = {
@@ -82,18 +79,18 @@ class ReportReportParameterRepositoryImpl extends ReportReportParameterRepositor
   override def delete(db: Database, id: String): Unit = {
     val getById = reportReportParameterQuery
       .filter(_.id === id)
-    Await.result(db.run(getById.delete), queryTimeout)
+    Await.result(db.run(getById.delete.withPinnedSession), queryTimeout)
   }
 
   override def deleteByReportId(db: Database, id: String): Unit = {
     val getById = reportReportParameterQuery
       .filter(_.reportId === id)
-    Await.result(db.run(getById.delete), queryTimeout)
+    Await.result(db.run(getById.delete.withPinnedSession), queryTimeout)
   }
 
   override def deleteByReportParameterId(db: Database, id: String): Unit = {
     val getById = reportReportParameterQuery
       .filter(_.reportParameterId === id)
-    Await.result(db.run(getById.delete), queryTimeout)
+    Await.result(db.run(getById.delete.withPinnedSession), queryTimeout)
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportRepositoryImpl.scala
@@ -17,15 +17,12 @@ class ReportRepositoryImpl extends ReportRepository {
       limit: Int = -1,
       templateId: String = "",
   ): (Seq[Report], Int) = {
-    var filtered = reportQuery.filter(_.workspaceId === workspaceId)
-    if (templateId.nonEmpty) {
-      filtered = filtered.filter(_.reportTemplateId === templateId)
-    }
+    val base = reportQuery.filter(_.workspaceId === workspaceId)
+    val filtered = if (templateId.nonEmpty) base.filter(_.reportTemplateId === templateId) else base
     val count = Await.result(db.run(filtered.length.result), queryTimeout)
-    if (limit > 0) {
-      filtered = filtered.drop(offset).take(limit)
-    }
-    val result = Await.result(db.run(filtered.result), queryTimeout)
+    val withOffset = if (offset > 0) filtered.drop(offset) else filtered
+    val paged = if (limit > 0) withOffset.take(limit) else withOffset
+    val result = Await.result(db.run(paged.result), queryTimeout)
     (result, count)
   }
 
@@ -36,24 +33,17 @@ class ReportRepositoryImpl extends ReportRepository {
       limit: Int = -1,
       templateId: String = "",
   ): (Seq[Report], Int) = {
-    var getById = reportQuery
+    val base = reportQuery
       .filter(_.workspaceId === workspaceId)
       .join(templateQuery)
       .on(_.reportTemplateId === _.id)
       .sortBy(_._1.id)
-
-    if (templateId.nonEmpty) {
-      getById = getById.filter(_._1.reportTemplateId === templateId)
-    }
-    val count = Await.result(db.run(getById.length.result), queryTimeout)
-    if (offset > 0) {
-      getById = getById.drop(offset)
-    }
-    if (limit > 0) {
-      getById = getById.take(limit)
-    }
-
-    val result = Await.result(db.run(getById.result), queryTimeout)
+    val filtered =
+      if (templateId.nonEmpty) base.filter(_._1.reportTemplateId === templateId) else base
+    val count = Await.result(db.run(filtered.length.result), queryTimeout)
+    val withOffset = if (offset > 0) filtered.drop(offset) else filtered
+    val paged = if (limit > 0) withOffset.take(limit) else withOffset
+    val result = Await.result(db.run(paged.result), queryTimeout)
     (result, count)
   }
 
@@ -100,6 +90,6 @@ class ReportRepositoryImpl extends ReportRepository {
     val getById = reportQuery
       .filter(_.workspaceId === workspaceId)
       .filter(_.id === id)
-    Await.result(db.run(getById.delete), queryTimeout)
+    Await.result(db.run(getById.delete.withPinnedSession), queryTimeout)
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportTemplateRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportTemplateRepositoryImpl.scala
@@ -15,12 +15,11 @@ class ReportTemplateRepositoryImpl extends ReportTemplateRepository {
       offset: Int,
       limit: Int,
   ): (Seq[ReportTemplate], Int) = {
-    var filtered = templateQuery.filter(_.workspaceId === workspaceId)
+    val filtered = templateQuery.filter(_.workspaceId === workspaceId)
     val count = Await.result(db.run(filtered.length.result), queryTimeout)
-    if (limit > 0) {
-      filtered = filtered.drop(offset).take(limit)
-    }
-    val result = Await.result(db.run(filtered.result), queryTimeout)
+    val withOffset = if (offset > 0) filtered.drop(offset) else filtered
+    val paged = if (limit > 0) withOffset.take(limit) else withOffset
+    val result = Await.result(db.run(paged.result), queryTimeout)
     (result, count)
   }
 

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/storage/s3/impl/AwsS3RepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/storage/s3/impl/AwsS3RepositoryImpl.scala
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.s3.presigner.model._
 
 import java.nio.file.{Files, Path}
 import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
 import scala.util.Using
 
 trait S3ClientFactory {
@@ -50,14 +51,16 @@ class AwsS3RepositoryImpl @Inject() (
     storageRepository: StorageS3Repository,
     s3ClientFactory: S3ClientFactory = new DefaultS3ClientFactory(),
 ) extends AwsS3Repository {
+  // 認証情報のローテーション時に古いクライアントを破棄するため、認証情報も含めたキーでキャッシュする
+  private val clientCache = new ConcurrentHashMap[String, S3Client]()
+  private val presignerCache = new ConcurrentHashMap[String, S3Presigner]()
+
   override def get(workspaceId: String, key: String): Path = {
     val storage = this.getStorage(workspaceId)
     val request = GetObjectRequest.builder().bucket(storage.s3BucketName).key(key).build()
     val file = Files.createTempFile("", ".tmp")
-    Using.resource(s3ClientFactory.createClient(storage)) { client =>
-      Using.resource(client.getObject(request)) { response =>
-        Files.copy(response, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
-      }
+    Using.resource(client(storage).getObject(request)) { response =>
+      Files.copy(response, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
     }
     file
   }
@@ -65,17 +68,13 @@ class AwsS3RepositoryImpl @Inject() (
   override def create(workspaceId: String, key: String, file: Path): Unit = {
     val storage = this.getStorage(workspaceId)
     val request = PutObjectRequest.builder().bucket(storage.s3BucketName).key(key).build()
-    Using(s3ClientFactory.createClient(storage)) { client =>
-      client.putObject(request, file)
-    }
+    client(storage).putObject(request, file)
   }
 
   override def delete(workspaceId: String, key: String): Unit = {
     val storage = this.getStorage(workspaceId)
     val request = DeleteObjectRequest.builder().bucket(storage.s3BucketName).key(key).build()
-    Using(s3ClientFactory.createClient(storage)) { client =>
-      client.deleteObject(request)
-    }
+    client(storage).deleteObject(request)
   }
 
   override def url(workspaceId: String, key: String): String = {
@@ -86,10 +85,27 @@ class AwsS3RepositoryImpl @Inject() (
       .getObjectRequest(getObjectRequest)
       .signatureDuration(Duration.ofSeconds(Config.PRESIGNED_URL_EXPIRATION))
       .build()
-    Using(s3ClientFactory.createPresignerClient(storage)) { client =>
-      client.presignGetObject(request)
-    }.get.url().toString
+    presigner(storage).presignGetObject(request).url().toString
   }
+
+  def shutdown(): Unit = {
+    clientCache.values().forEach(c => Using(c)(_ => ()))
+    clientCache.clear()
+    presignerCache.values().forEach(p => Using(p)(_ => ()))
+    presignerCache.clear()
+  }
+
+  private def client(storage: StorageS3Model): S3Client =
+    clientCache.computeIfAbsent(cacheKey(storage), _ => s3ClientFactory.createClient(storage))
+
+  private def presigner(storage: StorageS3Model): S3Presigner =
+    presignerCache.computeIfAbsent(
+      cacheKey(storage),
+      _ => s3ClientFactory.createPresignerClient(storage),
+    )
+
+  private def cacheKey(storage: StorageS3Model): String =
+    s"${storage.id}:${storage.awsRegion}:${storage.awsAccessKeyId}"
 
   private def getStorage(workspaceId: String): StorageS3Model = {
     val storageList = storageRepository.gets(db, workspaceId)

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportGroupReportRepositoryImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportGroupReportRepositoryImplSpec.scala
@@ -98,12 +98,21 @@ class ReportGroupReportRepositoryImplSpec
     count should equal(10)
   }
 
-  it should "ignore pagination when limit is -1" in {
+  it should "return all rows when offset=0 and limit=-1" in {
+    (1 to 10).foreach(_ => insertReportGroupReport())
+
+    val (result, count) = repository.gets(db, offset = 0, limit = -1)
+
+    result should have size 10
+    count should equal(10)
+  }
+
+  it should "apply offset even when limit is -1" in {
     (1 to 10).foreach(_ => insertReportGroupReport())
 
     val (result, count) = repository.gets(db, offset = 5, limit = -1)
 
-    result should have size 10
+    result should have size 5
     count should equal(10)
   }
 

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportReportParameterRepositoryImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportReportParameterRepositoryImplSpec.scala
@@ -98,12 +98,21 @@ class ReportReportParameterRepositoryImplSpec
     count should equal(10)
   }
 
-  it should "ignore pagination when limit is -1" in {
+  it should "return all rows when offset=0 and limit=-1" in {
+    (1 to 10).foreach(_ => insertReportReportParameter())
+
+    val (result, count) = repository.gets(db, offset = 0, limit = -1)
+
+    result should have size 10
+    count should equal(10)
+  }
+
+  it should "apply offset even when limit is -1" in {
     (1 to 10).foreach(_ => insertReportReportParameter())
 
     val (result, count) = repository.gets(db, offset = 5, limit = -1)
 
-    result should have size 10
+    result should have size 5
     count should equal(10)
   }
 

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/storage/s3/impl/AwsS3RepositoryImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/storage/s3/impl/AwsS3RepositoryImplSpec.scala
@@ -81,7 +81,37 @@ class AwsS3RepositoryImplSpec extends AnyFlatSpec with Matchers with MockitoSuga
 
     verify(storageRepository).gets(db, workspaceId)
     verify(s3ClientFactory).createClient(storage)
-    verify(s3Client).close()
+  }
+
+  it should "reuse cached S3Client across multiple calls" in {
+    val db = mock[Database]
+    val storageRepository = mock[StorageS3Repository]
+    val s3ClientFactory = mock[S3ClientFactory]
+    val s3Client = mock[S3Client]
+
+    val workspaceId = "workspace-id"
+    val storage = StorageS3Model(
+      id = "storage-id",
+      workspaceId = workspaceId,
+      s3BucketName = "test-bucket",
+      awsAccessKeyId = "test-access-key",
+      awsSecretAccessKey = "test-secret-key",
+      awsRegion = "us-east-1",
+      createdAt = 0,
+      updatedAt = 0,
+    )
+
+    when(storageRepository.gets(db, workspaceId)).thenReturn(Seq(storage))
+    when(s3ClientFactory.createClient(storage)).thenReturn(s3Client)
+    when(s3Client.deleteObject(any[DeleteObjectRequest])).thenReturn(mock[DeleteObjectResponse])
+
+    val repository = new AwsS3RepositoryImpl(db, storageRepository, s3ClientFactory)
+
+    repository.delete(workspaceId, "a")
+    repository.delete(workspaceId, "b")
+    repository.delete(workspaceId, "c")
+
+    verify(s3ClientFactory, times(1)).createClient(storage)
   }
 
   "create" should "upload file to S3 bucket" in {


### PR DESCRIPTION
## Summary

infrastructure 配下のコードレビュー (#276 で MUST 対応済) で検出された SHOULD 指摘のうち #7〜#12 に対応します。

### 修正内容

| # | 対象 | 内容 |
|---|------|------|
| #7 | `CacheWrapper` | 不要な `ReentrantReadWriteLock` を撤去。Jedis Pool 自体がスレッドセーフなため、ロック保持中の Redis 通信で全リクエストが直列化されていた問題を解消 |
| #8 | `ConnectionPool` | `mutable.Map + this.synchronized` を `ConcurrentHashMap.computeIfAbsent` に置き換え。`HikariPool.getConnection()` がロック内で呼ばれて全プール接続取得が直列化されていたボトルネックを解消 |
| #9 | `AwsS3RepositoryImpl` | workspace 単位で `S3Client` / `S3Presigner` をキャッシュ化し、リクエスト毎の生成コストを削減。`shutdown()` メソッドでアプリ停止時の解放経路を追加 |
| #10 | `Report*RepositoryImpl.gets` 系 | `offset` と `limit` を独立に判定するよう統一。`limit ≤ 0` のとき `offset` が無視される潜在バグと無意味な `drop(0)` を除去 |
| #11 | `delete` クエリ群 | `withPinnedSession` を一貫して付与。Slick で副作用クエリが別接続で実行されないことを保証 |
| #12 | `DatabaseFactory` / `Config` | `numThreads` / `poolSize` / `keepAliveConnection` をハードコードから環境変数 (`DB_NUM_THREADS` / `DB_POOL_SIZE` / `DB_KEEP_ALIVE_CONNECTION`) に外出し。`keepAliveConnection` のデフォルトは本番でリソース解放を阻害する `true` から `false` に変更 |

### スコープ外: #13 / #14

| # | 内容 | 別 PR で対応する理由 |
|---|------|----------------------|
| #13 | 楽観ロック適用 | `update` を `versions` 条件付き UPDATE に変更すると 0 件更新時の例外（`OptimisticLockException` 等）を usecase / presentation 層へ伝播させる必要があり、API レスポンス仕様（409 Conflict 返却）も含めた設計議論が必要 |
| #14 | DataSource / StorageS3 認証情報の暗号化 | KMS / Vault 連携の有無、暗号鍵のローテーション戦略、既存平文データのバッチマイグレーション計画が事前合意必要 |

## Behavioral changes

- `DB_KEEP_ALIVE_CONNECTION` のデフォルトが `true` → `false` に変更されています。既存環境で意図的に `true` を使っている場合は環境変数で明示してください。
- `AwsS3RepositoryImpl` は workspace 単位で S3Client をキャッシュします。認証情報のローテーション時はアプリ再起動するか、`shutdown()` 相当の解放処理を呼ぶ運用が必要です（cacheKey に accessKeyId を含めているため、credential 自体が更新されれば次回リクエストで新クライアントが作られる前提）。

## Test plan

- [x] `sbt compile` 成功
- [x] `sbt test` 全 613 件パス（#10 修正に伴いページングテストを 2 件更新、#9 のキャッシュ化を保証するテストを 1 件追加）
- [ ] CI green
- [ ] レビュアー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)