### PR TITLE
feat: 楽観ロックと認証情報の暗号化を導入 (#13 / #14)

### DIFF
--- a/src/main/scala/jp/ijufumi/openreports/exceptions/OptimisticLockException.scala
+++ b/src/main/scala/jp/ijufumi/openreports/exceptions/OptimisticLockException.scala
@@ -1,0 +1,4 @@
+package jp.ijufumi.openreports.exceptions
+
+class OptimisticLockException(message: String = null, cause: Throwable = null)
+    extends Exception(message, cause) {}

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/converter/DataSourceConverter.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/converter/DataSourceConverter.scala
@@ -5,6 +5,7 @@ import jp.ijufumi.openreports.infrastructure.persistence.entity.{
   DataSource => DataSourceEntity,
   DriverType => DriverTypeEntity,
 }
+import jp.ijufumi.openreports.utils.Crypto
 
 object DataSourceConverter {
   def toDomain(entity: DataSourceEntity): DataSourceModel = {
@@ -13,7 +14,7 @@ object DataSourceConverter {
       entity.name,
       entity.url,
       entity.username,
-      entity.password,
+      Crypto.decrypt(entity.password),
       entity.driverTypeId,
       DataSourceModel.maxPoolSize,
       entity.workspaceId,
@@ -29,7 +30,7 @@ object DataSourceConverter {
       entity._1.name,
       entity._1.url,
       entity._1.username,
-      entity._1.password,
+      Crypto.decrypt(entity._1.password),
       entity._1.driverTypeId,
       DataSourceModel.maxPoolSize,
       entity._1.workspaceId,
@@ -46,7 +47,7 @@ object DataSourceConverter {
       model.name,
       model.url,
       model.username,
-      model.password,
+      Crypto.encrypt(model.password),
       model.driverTypeId,
       model.workspaceId,
       model.createdAt,

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/converter/StorageS3Converter.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/converter/StorageS3Converter.scala
@@ -2,14 +2,15 @@ package jp.ijufumi.openreports.infrastructure.persistence.converter
 
 import jp.ijufumi.openreports.domain.models.entity.{StorageS3 => StorageS3Model}
 import jp.ijufumi.openreports.infrastructure.persistence.entity.{StorageS3 => StorageS3Entity}
+import jp.ijufumi.openreports.utils.Crypto
 
 object StorageS3Converter {
   def toDomain(entity: StorageS3Entity): StorageS3Model = {
     StorageS3Model(
       entity.id,
       entity.workspaceId,
-      entity.awsAccessKeyId,
-      entity.awsSecretAccessKey,
+      Crypto.decrypt(entity.awsAccessKeyId),
+      Crypto.decrypt(entity.awsSecretAccessKey),
       entity.awsRegion,
       entity.s3BucketName,
       entity.createdAt,
@@ -22,8 +23,8 @@ object StorageS3Converter {
     StorageS3Entity(
       model.id,
       model.workspaceId,
-      model.awsAccessKeyId,
-      model.awsSecretAccessKey,
+      Crypto.encrypt(model.awsAccessKeyId),
+      Crypto.encrypt(model.awsSecretAccessKey),
       model.awsRegion,
       model.s3BucketName,
       model.createdAt,

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/DataSourceRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/DataSourceRepositoryImpl.scala
@@ -2,7 +2,10 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.repository.DataSourceRepository
 import jp.ijufumi.openreports.domain.models.entity.DataSource
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.converter.DataSourceConverter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{DataSource => DataSourceEntity}
+import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
 
@@ -58,8 +61,17 @@ class DataSourceRepositoryImpl extends DataSourceRepository {
   }
 
   override def update(db: Database, dataSource: DataSource): Unit = {
-    val updateQuery = dataSourceQuery.insertOrUpdate(dataSource).withPinnedSession
-    Await.result(db.run(updateQuery), queryTimeout)
+    val newEntity: DataSourceEntity =
+      dataSource.copy(updatedAt = Dates.currentTimestamp(), versions = dataSource.versions + 1)
+    val q = dataSourceQuery
+      .filter(_.id === dataSource.id)
+      .filter(_.versions === dataSource.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"DataSource id=${dataSource.id} was modified concurrently or does not exist",
+      )
+    }
   }
 
   override def delete(db: Database, workspaceId: String, id: String): Unit = {

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/MemberRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/MemberRepositoryImpl.scala
@@ -3,9 +3,12 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 import scala.concurrent.Await
 import jp.ijufumi.openreports.domain.repository.MemberRepository
 import jp.ijufumi.openreports.domain.models.entity.Member
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
+import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
 import jp.ijufumi.openreports.infrastructure.persistence.converter.MemberConverter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{Member => MemberEntity}
 
 class MemberRepositoryImpl extends MemberRepository {
   override def getById(db: Database, id: String): Option[Member] = {
@@ -45,8 +48,17 @@ class MemberRepositoryImpl extends MemberRepository {
   }
 
   override def update(db: Database, member: Member): Unit = {
-    val query = memberQuery.insertOrUpdate(member).withPinnedSession
-    Await.result(db.run(query), queryTimeout)
+    val newEntity: MemberEntity =
+      member.copy(updatedAt = Dates.currentTimestamp(), versions = member.versions + 1)
+    val q = memberQuery
+      .filter(_.id === member.id)
+      .filter(_.versions === member.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"Member id=${member.id} was modified concurrently or does not exist",
+      )
+    }
   }
 
   override def delete(db: Database, id: String): Unit = {

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportGroupReportRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportGroupReportRepositoryImpl.scala
@@ -2,10 +2,14 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.repository.ReportGroupReportRepository
 import jp.ijufumi.openreports.domain.models.entity.ReportGroupReport
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
 import jp.ijufumi.openreports.infrastructure.persistence.converter.ReportGroupReportConverter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{
+  ReportGroupReport => ReportGroupReportEntity,
+}
 
 import scala.concurrent.Await
 
@@ -64,11 +68,17 @@ class ReportGroupReportRepositoryImpl extends ReportGroupReportRepository {
   }
 
   override def update(db: Database, model: ReportGroupReport): Unit = {
-    val newModel = model.copy(updatedAt = Dates.currentTimestamp())
-    val entity: jp.ijufumi.openreports.infrastructure.persistence.entity.ReportGroupReport =
-      newModel
-    val updateQuery = reportGroupReportQuery.insertOrUpdate(entity).withPinnedSession
-    Await.result(db.run(updateQuery), queryTimeout)
+    val newEntity: ReportGroupReportEntity =
+      model.copy(updatedAt = Dates.currentTimestamp(), versions = model.versions + 1)
+    val q = reportGroupReportQuery
+      .filter(_.id === model.id)
+      .filter(_.versions === model.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"ReportGroupReport id=${model.id} was modified concurrently or does not exist",
+      )
+    }
   }
 
   override def delete(db: Database, id: String): Unit = {

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportGroupRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportGroupRepositoryImpl.scala
@@ -2,7 +2,9 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.repository.ReportGroupRepository
 import jp.ijufumi.openreports.domain.models.entity.ReportGroup
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.converter.ReportGroupConverter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{ReportGroup => ReportGroupEntity}
 import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
@@ -42,9 +44,15 @@ class ReportGroupRepositoryImpl extends ReportGroupRepository {
   }
 
   override def update(db: Database, model: ReportGroup): Unit = {
-    val newModel = model.copy(updatedAt = Dates.currentTimestamp())
-    val updateQuery = reportGroupQuery.insertOrUpdate(newModel).withPinnedSession
-    Await.result(db.run(updateQuery), queryTimeout)
+    val newEntity: ReportGroupEntity =
+      model.copy(updatedAt = Dates.currentTimestamp(), versions = model.versions + 1)
+    val q = reportGroupQuery.filter(_.id === model.id).filter(_.versions === model.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"ReportGroup id=${model.id} was modified concurrently or does not exist",
+      )
+    }
   }
 
   override def delete(db: Database, workspaceId: String, id: String): Unit = {

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportParameterRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportParameterRepositoryImpl.scala
@@ -2,7 +2,11 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.repository.ReportParameterRepository
 import jp.ijufumi.openreports.domain.models.entity.ReportParameter
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.converter.ReportParameterConverter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{
+  ReportParameter => ReportParameterEntity,
+}
 import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
@@ -42,9 +46,15 @@ class ReportParameterRepositoryImpl extends ReportParameterRepository {
   }
 
   override def update(db: Database, model: ReportParameter): Unit = {
-    val newModel = model.copy(updatedAt = Dates.currentTimestamp())
-    val updateQuery = reportParameterQuery.insertOrUpdate(newModel).withPinnedSession
-    Await.result(db.run(updateQuery), queryTimeout)
+    val newEntity: ReportParameterEntity =
+      model.copy(updatedAt = Dates.currentTimestamp(), versions = model.versions + 1)
+    val q = reportParameterQuery.filter(_.id === model.id).filter(_.versions === model.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"ReportParameter id=${model.id} was modified concurrently or does not exist",
+      )
+    }
   }
 
   override def delete(db: Database, workspaceId: String, id: String): Unit = {

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportReportParameterRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportReportParameterRepositoryImpl.scala
@@ -2,8 +2,12 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.repository.ReportReportParameterRepository
 import jp.ijufumi.openreports.domain.models.entity.ReportReportParameter
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.converter.ReportReportParameterConverter
 import jp.ijufumi.openreports.infrastructure.persistence.converter.ReportReportParameterConverter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{
+  ReportReportParameter => ReportReportParameterEntity,
+}
 import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
@@ -69,11 +73,17 @@ class ReportReportParameterRepositoryImpl extends ReportReportParameterRepositor
   }
 
   override def update(db: Database, model: ReportReportParameter): Unit = {
-    val newModel = model.copy(updatedAt = Dates.currentTimestamp())
-    val entity: jp.ijufumi.openreports.infrastructure.persistence.entity.ReportReportParameter =
-      newModel
-    val updateQuery = reportReportParameterQuery.insertOrUpdate(entity).withPinnedSession
-    Await.result(db.run(updateQuery), queryTimeout)
+    val newEntity: ReportReportParameterEntity =
+      model.copy(updatedAt = Dates.currentTimestamp(), versions = model.versions + 1)
+    val q = reportReportParameterQuery
+      .filter(_.id === model.id)
+      .filter(_.versions === model.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"ReportReportParameter id=${model.id} was modified concurrently or does not exist",
+      )
+    }
   }
 
   override def delete(db: Database, id: String): Unit = {

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportRepositoryImpl.scala
@@ -2,7 +2,9 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.repository.ReportRepository
 import jp.ijufumi.openreports.domain.models.entity.Report
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.converter.ReportConverter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{Report => ReportEntity}
 import slick.jdbc.PostgresProfile.api._
 import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
@@ -81,9 +83,15 @@ class ReportRepositoryImpl extends ReportRepository {
   }
 
   override def update(db: Database, model: Report): Unit = {
-    val newModel = model.copy(updatedAt = Dates.currentTimestamp())
-    val updateQuery = reportQuery.insertOrUpdate(newModel).withPinnedSession
-    Await.result(db.run(updateQuery), queryTimeout)
+    val newEntity: ReportEntity =
+      model.copy(updatedAt = Dates.currentTimestamp(), versions = model.versions + 1)
+    val q = reportQuery.filter(_.id === model.id).filter(_.versions === model.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"Report id=${model.id} was modified concurrently or does not exist",
+      )
+    }
   }
 
   override def delete(db: Database, workspaceId: String, id: String): Unit = {

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportTemplateRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/ReportTemplateRepositoryImpl.scala
@@ -2,7 +2,12 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.repository.ReportTemplateRepository
 import jp.ijufumi.openreports.domain.models.entity.ReportTemplate
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.converter.ReportTemplateConverter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{
+  ReportTemplate => ReportTemplateEntity,
+}
+import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
 
@@ -42,8 +47,15 @@ class ReportTemplateRepositoryImpl extends ReportTemplateRepository {
   }
 
   override def update(db: Database, model: ReportTemplate): Unit = {
-    val updateQuery = templateQuery.insertOrUpdate(model).withPinnedSession
-    Await.result(db.run(updateQuery), queryTimeout)
+    val newEntity: ReportTemplateEntity =
+      model.copy(updatedAt = Dates.currentTimestamp(), versions = model.versions + 1)
+    val q = templateQuery.filter(_.id === model.id).filter(_.versions === model.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"ReportTemplate id=${model.id} was modified concurrently or does not exist",
+      )
+    }
   }
 
   override def delete(db: Database, workspaceId: String, id: String): Unit = {

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/StorageS3RepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/StorageS3RepositoryImpl.scala
@@ -3,7 +3,9 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 import slick.jdbc.PostgresProfile.api._
 import jp.ijufumi.openreports.domain.repository.StorageS3Repository
 import jp.ijufumi.openreports.domain.models.entity.StorageS3
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.converter.StorageS3Converter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{StorageS3 => StorageS3Entity}
 import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
 
@@ -35,8 +37,14 @@ class StorageS3RepositoryImpl extends StorageS3Repository {
   }
 
   override def update(db: Database, model: StorageS3): Unit = {
-    val newModel = model.copy(updatedAt = Dates.currentTimestamp())
-    val updateQuery = storageQuery.insertOrUpdate(newModel).withPinnedSession
-    Await.result(db.run(updateQuery), queryTimeout)
+    val newEntity: StorageS3Entity =
+      model.copy(updatedAt = Dates.currentTimestamp(), versions = model.versions + 1)
+    val q = storageQuery.filter(_.id === model.id).filter(_.versions === model.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"StorageS3 id=${model.id} was modified concurrently or does not exist",
+      )
+    }
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/WorkspaceMemberRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/WorkspaceMemberRepositoryImpl.scala
@@ -2,7 +2,12 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.repository.WorkspaceMemberRepository
 import jp.ijufumi.openreports.domain.models.entity.WorkspaceMember
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.converter.WorkspaceMemberConverter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{
+  WorkspaceMember => WorkspaceMemberEntity,
+}
+import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
 
@@ -71,8 +76,21 @@ class WorkspaceMemberRepositoryImpl extends WorkspaceMemberRepository {
   }
 
   override def update(db: Database, workspaceMember: WorkspaceMember): Unit = {
-    val updateQuery = workspaceMemberQuery.insertOrUpdate(workspaceMember).withPinnedSession
-    Await.result(db.run(updateQuery), queryTimeout)
+    val newEntity: WorkspaceMemberEntity = workspaceMember.copy(
+      updatedAt = Dates.currentTimestamp(),
+      versions = workspaceMember.versions + 1,
+    )
+    val q = workspaceMemberQuery
+      .filter(_.workspaceId === workspaceMember.workspaceId)
+      .filter(_.memberId === workspaceMember.memberId)
+      .filter(_.versions === workspaceMember.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"WorkspaceMember workspaceId=${workspaceMember.workspaceId} " +
+          s"memberId=${workspaceMember.memberId} was modified concurrently or does not exist",
+      )
+    }
   }
 
   override def delete(db: Database, workspaceId: String, memberId: String): Unit = {

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/WorkspaceRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/WorkspaceRepositoryImpl.scala
@@ -2,7 +2,9 @@ package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.repository.WorkspaceRepository
 import jp.ijufumi.openreports.domain.models.entity.Workspace
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.converter.WorkspaceConverter.conversions._
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{Workspace => WorkspaceEntity}
 import jp.ijufumi.openreports.utils.Dates
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
@@ -37,9 +39,15 @@ class WorkspaceRepositoryImpl extends WorkspaceRepository {
   }
 
   override def update(db: Database, workspace: Workspace): Option[Workspace] = {
-    val newModel = workspace.copy(updatedAt = Dates.currentTimestamp())
-    val updateQuery = workspaceQuery.insertOrUpdate(newModel).withPinnedSession
-    Await.result(db.run(updateQuery), queryTimeout)
+    val newEntity: WorkspaceEntity =
+      workspace.copy(updatedAt = Dates.currentTimestamp(), versions = workspace.versions + 1)
+    val q = workspaceQuery.filter(_.id === workspace.id).filter(_.versions === workspace.versions)
+    val affected = Await.result(db.run(q.update(newEntity).withPinnedSession), queryTimeout)
+    if (affected == 0) {
+      throw new OptimisticLockException(
+        s"Workspace id=${workspace.id} was modified concurrently or does not exist",
+      )
+    }
     getById(db, workspace.id)
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/presentation/controller/base/APIServletBase.scala
+++ b/src/main/scala/jp/ijufumi/openreports/presentation/controller/base/APIServletBase.scala
@@ -3,12 +3,14 @@ package jp.ijufumi.openreports.presentation.controller.base
 import jp.ijufumi.openreports.configs.Config
 import jp.ijufumi.openreports.domain.models.value.enums.{JdbcDriverClasses, RoleTypes, StorageTypes}
 import jp.ijufumi.openreports.domain.models.entity.{Member => MemberModel}
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.utils.Logging
 import org.json4s.{jvalue2extractable, jvalue2monadic, DefaultFormats, Formats}
 import org.json4s.ext.EnumNameSerializer
 import org.scalatra.{
   ActionResult,
   BadRequest,
+  Conflict,
   CorsSupport,
   Forbidden,
   InternalServerError,
@@ -88,6 +90,10 @@ abstract class APIServletBase
     hookResult(Forbidden(obj))
   }
 
+  def conflict(obj: Any): ActionResult = {
+    hookResult(Conflict(obj))
+  }
+
   // 5xx
   def internalServerError(obj: Any): ActionResult = {
     hookResult(InternalServerError(obj))
@@ -123,10 +129,12 @@ abstract class APIServletBase
   }
 
   error {
-    case t => {
+    case e: OptimisticLockException =>
+      logger.warn(e.getMessage, e)
+      conflict(Map("error" -> "resource was modified concurrently"))
+    case t =>
       logger.error(t.getMessage, t)
       internalServerError(t)
-    }
   }
 
   protected def extractBody[T: Manifest](): T = parse(request.body).extract[T]

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/converter/DataSourceConverterSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/converter/DataSourceConverterSpec.scala
@@ -1,0 +1,49 @@
+package jp.ijufumi.openreports.infrastructure.persistence.converter
+
+import jp.ijufumi.openreports.domain.models.entity.{DataSource => DataSourceModel}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DataSourceConverterSpec extends AnyFlatSpec with Matchers {
+  "toEntity" should "encrypt the password" in {
+    val plain = "super-secret-password"
+    val model = DataSourceModel(
+      id = "id",
+      name = "ds",
+      url = "jdbc:postgresql://localhost/db",
+      username = "user",
+      password = plain,
+      driverTypeId = "driver-id",
+      maxPoolSize = 10,
+      workspaceId = "ws",
+      createdAt = 0,
+      updatedAt = 0,
+    )
+
+    val entity = DataSourceConverter.toEntity(model)
+
+    entity.password should not equal plain
+    entity.password should startWith("v1:")
+  }
+
+  "toDomain" should "decrypt the password roundtrip" in {
+    val plain = "round-trip-password"
+    val model = DataSourceModel(
+      id = "id",
+      name = "ds",
+      url = "jdbc:postgresql://localhost/db",
+      username = "user",
+      password = plain,
+      driverTypeId = "driver-id",
+      maxPoolSize = 10,
+      workspaceId = "ws",
+      createdAt = 0,
+      updatedAt = 0,
+    )
+
+    val entity = DataSourceConverter.toEntity(model)
+    val restored = DataSourceConverter.toDomain(entity)
+
+    restored.password should equal(plain)
+  }
+}

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/converter/StorageS3ConverterSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/converter/StorageS3ConverterSpec.scala
@@ -1,0 +1,50 @@
+package jp.ijufumi.openreports.infrastructure.persistence.converter
+
+import jp.ijufumi.openreports.domain.models.entity.{StorageS3 => StorageS3Model}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class StorageS3ConverterSpec extends AnyFlatSpec with Matchers {
+  "toEntity" should "encrypt the access key id and secret access key" in {
+    val accessKey = "AKIAEXAMPLEACCESSKEY"
+    val secret = "exampleSecretAccessKey1234"
+    val model = StorageS3Model(
+      id = "id",
+      workspaceId = "ws",
+      awsAccessKeyId = accessKey,
+      awsSecretAccessKey = secret,
+      awsRegion = "us-east-1",
+      s3BucketName = "bucket",
+      createdAt = 0,
+      updatedAt = 0,
+    )
+
+    val entity = StorageS3Converter.toEntity(model)
+
+    entity.awsAccessKeyId should not equal accessKey
+    entity.awsAccessKeyId should startWith("v1:")
+    entity.awsSecretAccessKey should not equal secret
+    entity.awsSecretAccessKey should startWith("v1:")
+  }
+
+  "toDomain" should "decrypt credentials roundtrip" in {
+    val accessKey = "AKIAEXAMPLEACCESSKEY"
+    val secret = "exampleSecretAccessKey1234"
+    val model = StorageS3Model(
+      id = "id",
+      workspaceId = "ws",
+      awsAccessKeyId = accessKey,
+      awsSecretAccessKey = secret,
+      awsRegion = "us-east-1",
+      s3BucketName = "bucket",
+      createdAt = 0,
+      updatedAt = 0,
+    )
+
+    val entity = StorageS3Converter.toEntity(model)
+    val restored = StorageS3Converter.toDomain(entity)
+
+    restored.awsAccessKeyId should equal(accessKey)
+    restored.awsSecretAccessKey should equal(secret)
+  }
+}

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/DataSourceRepositoryImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/DataSourceRepositoryImplSpec.scala
@@ -1,6 +1,7 @@
 package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.models.entity.{DataSource, DriverType}
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.H2DatabaseHelper
 import jp.ijufumi.openreports.infrastructure.persistence.entity.{DriverType => DriverTypeEntity}
 import jp.ijufumi.openreports.utils.IDs
@@ -243,6 +244,41 @@ class DataSourceRepositoryImplSpec
     result should be(defined)
     result.get.name should equal("Updated Name")
     result.get.url should equal("jdbc:postgresql://newhost:5432/newdb")
+  }
+
+  it should "increment versions on each update" in {
+    val workspaceId = IDs.ulid()
+    val driverType = createTestDriverType()
+    val dataSource = createTestDataSource(workspaceId, driverType.id)
+    repository.register(db, dataSource)
+
+    val afterFirst = repository.getById(db, workspaceId, dataSource.id)
+    afterFirst.get.versions should equal(1)
+
+    repository.update(db, afterFirst.get.copy(name = "v2"))
+    val afterSecond = repository.getById(db, workspaceId, dataSource.id)
+    afterSecond.get.versions should equal(2)
+    afterSecond.get.name should equal("v2")
+  }
+
+  it should "throw OptimisticLockException when versions do not match" in {
+    val workspaceId = IDs.ulid()
+    val driverType = createTestDriverType()
+    val dataSource = createTestDataSource(workspaceId, driverType.id)
+    repository.register(db, dataSource)
+    val stale = repository.getById(db, workspaceId, dataSource.id).get
+
+    repository.update(db, stale.copy(name = "first"))
+
+    an[OptimisticLockException] should be thrownBy
+      repository.update(db, stale.copy(name = "second"))
+  }
+
+  it should "throw OptimisticLockException when target row does not exist" in {
+    val driverType = createTestDriverType()
+    val dataSource = createTestDataSource(IDs.ulid(), driverType.id)
+
+    an[OptimisticLockException] should be thrownBy repository.update(db, dataSource)
   }
 
   "delete" should "remove data source from database" in {

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/WorkspaceMemberRepositoryImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/WorkspaceMemberRepositoryImplSpec.scala
@@ -1,6 +1,7 @@
 package jp.ijufumi.openreports.infrastructure.persistence.repository
 
 import jp.ijufumi.openreports.domain.models.entity.{Member, WorkspaceMember}
+import jp.ijufumi.openreports.exceptions.OptimisticLockException
 import jp.ijufumi.openreports.infrastructure.persistence.H2DatabaseHelper
 import jp.ijufumi.openreports.utils.IDs
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
@@ -205,6 +206,19 @@ class WorkspaceMemberRepositoryImplSpec
     val result = repository.getById(db, workspaceId, member.id)
     result should be(defined)
     result.get.roleId should equal("new-role")
+  }
+
+  it should "throw OptimisticLockException when versions do not match" in {
+    val workspaceId = IDs.ulid()
+    val member = createTestMember()
+    val workspaceMember = createTestWorkspaceMember(workspaceId, member.id, "old-role")
+    repository.register(db, workspaceMember)
+    val stale = repository.getById(db, workspaceId, member.id).get
+
+    repository.update(db, stale.copy(roleId = "first"))
+
+    an[OptimisticLockException] should be thrownBy
+      repository.update(db, stale.copy(roleId = "second"))
   }
 
   "delete" should "remove workspace member from database" in {


### PR DESCRIPTION
## Summary

infrastructure 層レビューの残りの 2 件、#13（楽観ロック適用）と #14（認証情報の暗号化）に対応します。PR #276・#277 を踏まえた最終 PR です。

### #13 楽観ロック

- `exceptions/OptimisticLockException` を新規追加
- 11 リポジトリの `update` メソッドを `insertOrUpdate` から **`versions` 条件付き UPDATE** に置換し、UPDATE 時に `versions += 1`。0 件更新時は `OptimisticLockException` を投げる
  - Member / Report / ReportGroup / ReportGroupReport / ReportParameter / ReportReportParameter / ReportTemplate / DataSource / Workspace / WorkspaceMember / StorageS3
  - WorkspaceMember は複合キー `(workspaceId, memberId, versions)` の三条件で WHERE 句を構築
- `APIServletBase` の `error` ハンドラで `OptimisticLockException` をキャッチし **409 Conflict** に変換（合意済み方針）
  - レスポンスボディは `{ "error": "resource was modified concurrently" }`
  - ログレベルは `warn`（5xx ではないため）

### #14 認証情報の暗号化

既存データなしの前提（合意済み）でマイグレーションスクリプト不要。

- `DataSourceConverter` で `password` を `Crypto.encrypt` / `Crypto.decrypt`
- `StorageS3Converter` で `awsAccessKeyId` / `awsSecretAccessKey` を同様に暗号化
- 既存 `utils/Crypto` の AES-GCM 実装（`HASH_KEY` 由来 SHA-256 → AES-256 鍵）を使用
- `Crypto.decrypt` は `v1:` プレフィックスがない値を素通しする実装なので、テスト用平文や旧データが混在しても透過

## Behavioral changes

- 同一 `versions` で複数回 `update` を投げると **2 回目以降が 409 を返す**ように変わります（楽観ロック）。フロントエンドは `update` 後にレスポンス（`getById` 結果含む）の `versions` を保持して次回送信する設計が必要です。
- `versions` を持たない呼び出し（楽観ロック非対応の古いクライアント）は、最初の `update` までは通るが、リトライや並行更新で 409 が返る可能性があります。
- DB に格納される `password` / `awsAccessKeyId` / `awsSecretAccessKey` は `v1:<base64>` 形式に変わります。直接 SQL で参照する運用ツールがある場合はご注意ください。

## Test plan

- [x] `sbt compile` 成功
- [x] `sbt test` 全 **621 件** パス（楽観ロック失敗テスト 4 件、コンバータ暗号化テスト 4 件追加）
- [ ] CI green
- [ ] レビュアー確認

## Notes for reviewer

- 楽観ロックの実装は `Slick の filter(_.versions === model.versions)` + `update(newEntity)` パターン。`insertOrUpdate` は upsert なので存在しない行に対してでも成功してしまうため、明示的な `update` に置換しています。
- 暗号鍵は環境変数 `HASH_KEY` を SHA-256 でダイジェストして 256bit AES 鍵に変換。鍵ローテーション時は `Crypto.decrypt` の `v1:` バージョン管理を拡張する想定（今回は未実装）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)