### PR TITLE
refactor: Docker / GitHub Actions の構成を近代化

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,12 @@
 .bsp
+.git
 .github
 .idea
 docker
 docs
 target
+project/target
+project/project
 
 .dockerignore
 .editorconfig

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # ---------------------------------------------------------------
       # レビュー開始: PRにリアクション・ラベル・コメントで通知

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ["17", "21", "25"]
+        java: ["21", "25"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -40,3 +40,28 @@ jobs:
         run: task compile
       - name: Test
         run: task test
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: "sbt"
+          cache-dependency-path: |
+            build.sbt
+            project/build.properties
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
+      - name: Run coverage
+        run: sbt clean coverage test coverageReport
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: scoverage-report
+          path: target/scala-*/scoverage-report/

--- a/.github/workflows/create-plantuml-images.yml
+++ b/.github/workflows/create-plantuml-images.yml
@@ -10,15 +10,16 @@ on:
 
 jobs:
   setup:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Install packages
         run: |
-          brew install plantuml
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends plantuml graphviz
       - name: Create image
         run: |
-          cat ./docs/db/diagram.puml | plantuml -tsvg -p > ./docs/db/diagram.svg
+          plantuml -tsvg -p < ./docs/db/diagram.puml > ./docs/db/diagram.svg
       - name: Commit image
         uses: EndBug/add-and-commit@v9
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,55 @@
-### This Dockerfile is for production
-FROM eclipse-temurin:21-jdk-jammy
+# syntax=docker/dockerfile:1.7
+# ============================================================
+# Stage 1: build assembly jar
+# ============================================================
+FROM eclipse-temurin:25-jdk-noble AS builder
 
-RUN apt-get update && apt-get -y install curl gnupg postgresql-client
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list \
-&& echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list \
-&& curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add \
-&& apt-get update && apt-get -y install sbt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+    && install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" \
+        | gpg --dearmor -o /etc/apt/keyrings/sbt.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/sbt.gpg] https://repo.scala-sbt.org/scalasbt/debian all main" \
+        > /etc/apt/sources.list.d/sbt.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends sbt \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-ENV APP_DIR /app
-WORKDIR $APP_DIR
+WORKDIR /build
 
-COPY build.sbt .
-COPY scripts ./scripts
-COPY src ./src
 COPY project ./project
+COPY build.sbt ./
+RUN sbt update
+
+COPY src ./src
 COPY reports ./reports
+RUN sbt assembly \
+    && cp target/scala-*/open-reports-api.jar /build/open-reports-api.jar
 
-RUN sbt package
+# ============================================================
+# Stage 2: runtime
+# ============================================================
+FROM eclipse-temurin:25-jre-noble
 
-# TODO: need to change for production
-ENTRYPOINT ["bash", "/app/scripts/entrypoint.sh"]
+ENV DEBIAN_FRONTEND=noninteractive \
+    APP_DIR=/app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR ${APP_DIR}
+
+COPY --from=builder /build/open-reports-api.jar ./open-reports-api.jar
+COPY src/main/webapp ./src/main/webapp
+COPY reports ./reports
+COPY scripts/entrypoint-prod.sh ./scripts/entrypoint-prod.sh
+RUN chmod +x ./scripts/entrypoint-prod.sh
+
+EXPOSE 8080
+
+ENTRYPOINT ["bash", "/app/scripts/entrypoint-prod.sh"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,9 +25,7 @@ services:
         volume: {}
     working_dir: /app
   db:
-    build:
-      context: ./docker/postgres
-      dockerfile: Dockerfile
+    image: postgres:17-bookworm
     container_name: openreports-db
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
@@ -37,29 +35,17 @@ services:
       TZ: Asia/Tokyo
     networks:
       default: null
-    platform: linux/arm64
     ports:
-      - mode: ingress
-        target: 5432
-        published: "5432"
-        protocol: tcp
+      - "5432:5432"
     volumes:
-      - type: volume
-        source: db-data
-        target: /var/lib/postgresql/data
-        volume: {}
+      - db-data:/var/lib/postgresql/data
   redis:
-    build:
-      context: ./docker/redis
-      dockerfile: Dockerfile
+    image: redis:7.4-alpine
     container_name: openreports-redis
     ports:
       - "6379:6379"
     volumes:
-      - type: volume
-        source: redis-data
-        target: /data
-        volume: {}
+      - redis-data:/data
 networks:
   default:
     name: openreports

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,5 +1,5 @@
 ### This Dockerfile is for development, not for production
-FROM eclipse-temurin:21-jdk-jammy
+FROM eclipse-temurin:25-jdk-noble
 
 RUN apt-get update && apt-get -y install curl gnupg postgresql-client libreoffice fonts-ipaexfont
 

--- a/docker/libreoffice/Dockerfile
+++ b/docker/libreoffice/Dockerfile
@@ -1,6 +1,13 @@
-FROM centos:centos7
+FROM debian:bookworm-slim
 
-RUN yum -y update; yum clean all;
-RUN yum -y install deltarpm
-RUN yum -y install libreoffice* ipa-*-fonts
+ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libreoffice-core \
+        libreoffice-writer \
+        libreoffice-calc \
+        libreoffice-impress \
+        fonts-ipaexfont \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,8 +1,0 @@
-FROM postgres:14-bullseye
-
-# MAINTAINER postgre
-
-#RUN chmod 755 -R /var/lib/postgresql/data
-#COPY ./postgresql.conf /postgresql.conf
-# RUN chmod 644 /var/lib/postgresql/data/postgresql.conf
-#CMD cat /postgresql.conf  /var/lib/postgresql/data/postgresql.conf

--- a/docker/redis/Dockerfile
+++ b/docker/redis/Dockerfile
@@ -1,1 +1,0 @@
-FROM redis:latest

--- a/scripts/entrypoint-prod.sh
+++ b/scripts/entrypoint-prod.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+export PGPASSWORD="${DB_PASSWORD}"
+
+until psql -h "${DB_HOST}" -U "${DB_USER}" -p "${DB_PORT}" -c "\l" >/dev/null 2>&1; do
+  echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+echo "Postgres is up"
+
+if ! psql -h "${DB_HOST}" -U "${DB_USER}" -p "${DB_PORT}" -lqt \
+  | cut -d \| -f 1 | grep -qw "${DB_NAME}"; then
+  psql -h "${DB_HOST}" -U "${DB_USER}" -p "${DB_PORT}" \
+    -c "CREATE DATABASE ${DB_NAME} ENCODING 'UTF8';"
+fi
+
+# Flyway migration is expected to run as a separate deploy step
+# (e.g. `sbt flywayMigrate` from CI, or `flyway/flyway` as an init container).
+
+exec java ${JAVA_OPTS:-} -jar /app/open-reports-api.jar


### PR DESCRIPTION
## Summary
- **production Dockerfile をマルチステージ化** — builder で `sbt assembly`、runtime は JRE-only。`apt-key`（deprecated）を `signed-by` keyring に置き換え、重複 sources.list と apt キャッシュを除去
- **Java 21 → 25 (LTS)** に統一（builder / runtime / dev / CI coverage すべて）。dev の OS ベースも `jammy` → `noble`
- **libreoffice Dockerfile を脱 CentOS 7** — EOL の `centos:centos7` を `debian:bookworm-slim` に変更し、必要最小パッケージに絞る
- **中身が空の postgres/redis Dockerfile を削除** し、`compose.yaml` で `postgres:17-bookworm` / `redis:7.4-alpine` を直接指定
- **PlantUML workflow を macos-latest → ubuntu-latest** に変更し apt 経由でインストール（コスト約 1/10）
- **CI に coverage ジョブを追加**（Java 25 で `sbt clean coverage test coverageReport`、レポートを artifact 化）。matrix を `["21", "25"]` に整理し、`actions/checkout` を v6 に統一

## ⚠️ Breaking Change（要対応）
production Dockerfile の entrypoint から **Flyway マイグレーションを除外** しました（`sbt ~reStart` という dev hot-reload 動作も削除）。デプロイ手順に以下のいずれかを別ステップとして組み込む必要があります：
- `sbt flywayMigrate` を CI/CD パイプラインで実行
- `flyway/flyway` 公式イメージを init コンテナ等で実行

`scripts/entrypoint-prod.sh` 内のコメントにも記載済み。

## 補足
- `compose.yaml` の db / redis から `platform: linux/arm64` を削除（マルチアーキ image なのでホスト arch で自動選択される）。api はそのまま維持。
- `docker/postgres/postgresql.conf` は未参照ですが念のため残置。不要であれば別 PR で削除可。
- dev 用 `docker/api/Dockerfile` と `scripts/entrypoint.sh` は従来通り維持しています。

## Test plan
- [ ] `task build` でローカルビルドが成功することを確認
- [ ] `task up` で api / db / redis が起動し、`/health` が応答することを確認
- [ ] production Dockerfile の `docker build .` が成功し、生成された jar で `java -jar` 起動できることを確認
- [ ] `code-inspection` workflow が Java 21 / 25 ともに green
- [ ] `coverage` ジョブが完走し、scoverage-report が artifact として取得できる
- [ ] PlantUML workflow が ubuntu-latest 上で diagram.svg を生成できる
- [ ] デプロイフローに Flyway マイグレーションの別ステップを組み込む（運用側）

🤖 Generated with [Claude Code](https://claude.com/claude-code)