### PR TITLE
chore: GitHub Actions の参照を最新版の SHA に固定

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # ---------------------------------------------------------------
       # レビュー開始: PRにリアクション・ラベル・コメントで通知
@@ -106,7 +106,7 @@ jobs:
       # ---------------------------------------------------------------
       - name: Run Claude Code Review
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1
         with:
           # =============================================
           # 認証: 以下のどちらか一方を使用

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -22,9 +22,9 @@ jobs:
         java: ["21", "25"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -33,9 +33,9 @@ jobs:
             build.sbt
             project/build.properties
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt@93e926cbdb4a428e41b4ef754124ec82925ffdc2 # v1.1.23
       - name: Install Task
-        uses: go-task/setup-task@v1
+        uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
       - name: Build
         run: task compile
       - name: Test
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: "25"
@@ -56,11 +56,11 @@ jobs:
             build.sbt
             project/build.properties
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt@93e926cbdb4a428e41b4ef754124ec82925ffdc2 # v1.1.23
       - name: Run coverage
         run: sbt clean coverage test coverageReport
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: scoverage-report

--- a/.github/workflows/create-plantuml-images.yml
+++ b/.github/workflows/create-plantuml-images.yml
@@ -12,7 +12,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install packages
         run: |
           sudo apt-get update
@@ -21,7 +21,7 @@ jobs:
         run: |
           plantuml -tsvg -p < ./docs/db/diagram.puml > ./docs/db/diagram.svg
       - name: Commit image
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           author_name: Takafumi Iju
           author_email: ijufumi@gmail.com


### PR DESCRIPTION
## 概要

GitHub Actions ワークフローで利用している各アクションの参照を、可変なタグ（例: `@v4`）から不変なコミット SHA に固定する。あわせて各アクションを最新バージョンへ更新する。

タグ参照は同名のまま中身が差し替わる可能性があり、サプライチェーン攻撃の入口になりうるため、[GitHub 公式の Hardening Guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) に従い SHA 固定とする。可読性のため対応するバージョンはコメントとして併記する。

## 変更内容

- `actions/checkout` v6 → `de0fac2…` # v6.0.2
- `actions/setup-java` v5 → `be666c2…` # v5.2.0
- `actions/upload-artifact` v4 → `043fb46…` # v7.0.1（メジャーアップ）
- `sbt/setup-sbt` v1 → `93e926c…` # v1.1.23
- `go-task/setup-task` v1 → `3be4020…` # v2.0.0（メジャーアップ）
- `anthropics/claude-code-action` v1 → `51ea8ea…` # v1
- `EndBug/add-and-commit` v9 → `290ea2c…` # v10.0.0（メジャーアップ）

## 関連Issue

なし

<!-- REVIEW_FOCUS -->
- メジャーアップした 3 つのアクション（`upload-artifact` v4→v7、`setup-task` v1→v2、`add-and-commit` v9→v10）の破壊的変更が、現状の使い方に影響しないか
- SHA とコメント版数の対応に誤りがないか
<!-- /REVIEW_FOCUS -->

## チェックリスト

- [ ] ローカルで動作確認済み（未実施。CI 実行で確認）
- [ ] テストを追加・更新済み（該当なし）
- [ ] ドキュメントを更新済み（該当なし）