### PR TITLE
feat: access_token / refresh_token 機能を実装

### DIFF
--- a/src/main/resources/db/migration/V000002_00__create-refresh-tokens.sql
+++ b/src/main/resources/db/migration/V000002_00__create-refresh-tokens.sql
@@ -1,0 +1,16 @@
+-- create refresh_tokens
+create table refresh_tokens
+(
+  id            varchar(40)  primary key,
+  member_id     varchar(40)  not null,
+  refresh_token varchar(128) not null unique,
+  expired_at    bigint       not null,
+  used_at       bigint,
+  created_at    bigint       not null default extract(epoch from current_timestamp at time zone 'UTC'),
+  updated_at    bigint       not null default extract(epoch from current_timestamp at time zone 'UTC'),
+  versions      bigint       not null default 0,
+
+  foreign key (member_id) references members (id)
+);
+
+create index idx_refresh_tokens_member_id on refresh_tokens (member_id);

--- a/src/main/scala/jp/ijufumi/openreports/configs/Config.scala
+++ b/src/main/scala/jp/ijufumi/openreports/configs/Config.scala
@@ -42,6 +42,8 @@ object Config {
     getEnvIntValue("ACCESS_TOKEN_EXPIRATION_SEC", 600)
   val REFRESH_TOKEN_EXPIRATION_SEC: Integer =
     getEnvIntValue("REFRESH_TOKEN_EXPIRATION_SEC", 3600 * 4)
+  val REFRESH_TOKEN_GRACE_PERIOD_MILLIS: Long =
+    getEnvIntValue("REFRESH_TOKEN_GRACE_PERIOD_SEC", 5) * 1000L
   // for cache
   val REDIS_HOST: String = getEnvValue("REDIS_HOST", "localhost")
   val REDIS_PORT: Int = getEnvIntValue("REDIS_PORT", 6379)

--- a/src/main/scala/jp/ijufumi/openreports/configs/injectors/RepositoryModule.scala
+++ b/src/main/scala/jp/ijufumi/openreports/configs/injectors/RepositoryModule.scala
@@ -5,6 +5,7 @@ import jp.ijufumi.openreports.domain.repository.{
   DriverTypeRepository,
   FunctionRepository,
   MemberRepository,
+  RefreshTokenRepository,
   ReportGroupReportRepository,
   ReportGroupRepository,
   ReportParameterRepository,
@@ -22,6 +23,7 @@ import jp.ijufumi.openreports.infrastructure.persistence.repository.{
   DriverTypeRepositoryImpl,
   FunctionRepositoryImpl,
   MemberRepositoryImpl,
+  RefreshTokenRepositoryImpl,
   ReportGroupReportRepositoryImpl,
   ReportGroupRepositoryImpl,
   ReportParameterRepositoryImpl,
@@ -39,6 +41,7 @@ class RepositoryModule extends BaseModule {
   override def configure(): Unit = {
     super.configure()
     bindClass(classOf[MemberRepository], classOf[MemberRepositoryImpl])
+    bindClass(classOf[RefreshTokenRepository], classOf[RefreshTokenRepositoryImpl])
     bindClass(classOf[WorkspaceRepository], classOf[WorkspaceRepositoryImpl])
     bindClass(classOf[WorkspaceMemberRepository], classOf[WorkspaceMemberRepositoryImpl])
     bindClass(classOf[DataSourceRepository], classOf[DataSourceRepositoryImpl])

--- a/src/main/scala/jp/ijufumi/openreports/domain/models/entity/RefreshToken.scala
+++ b/src/main/scala/jp/ijufumi/openreports/domain/models/entity/RefreshToken.scala
@@ -1,0 +1,14 @@
+package jp.ijufumi.openreports.domain.models.entity
+
+import jp.ijufumi.openreports.utils.Dates
+
+case class RefreshToken(
+    id: String,
+    memberId: String,
+    refreshToken: String,
+    expiredAt: Long,
+    usedAt: Option[Long] = None,
+    createdAt: Long = Dates.currentTimestamp(),
+    updatedAt: Long = Dates.currentTimestamp(),
+    versions: Long = 1,
+)

--- a/src/main/scala/jp/ijufumi/openreports/domain/models/value/AuthTokens.scala
+++ b/src/main/scala/jp/ijufumi/openreports/domain/models/value/AuthTokens.scala
@@ -1,0 +1,6 @@
+package jp.ijufumi.openreports.domain.models.value
+
+case class AuthTokens(
+    accessToken: String,
+    refreshToken: Option[String],
+)

--- a/src/main/scala/jp/ijufumi/openreports/domain/repository/RefreshTokenRepository.scala
+++ b/src/main/scala/jp/ijufumi/openreports/domain/repository/RefreshTokenRepository.scala
@@ -1,0 +1,18 @@
+package jp.ijufumi.openreports.domain.repository
+
+import jp.ijufumi.openreports.domain.models.entity.RefreshToken
+import slick.jdbc.JdbcBackend.Database
+
+trait RefreshTokenRepository {
+  def getByToken(db: Database, refreshToken: String): Option[RefreshToken]
+
+  def register(db: Database, refreshToken: RefreshToken): Option[RefreshToken]
+
+  def markUsed(db: Database, refreshToken: String, usedAt: Long): Int
+
+  def deleteByToken(db: Database, refreshToken: String): Int
+
+  def deleteByMemberId(db: Database, memberId: String): Unit
+
+  def deleteExpired(db: Database, now: Long): Unit
+}

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/converter/RefreshTokenConverter.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/converter/RefreshTokenConverter.scala
@@ -1,0 +1,47 @@
+package jp.ijufumi.openreports.infrastructure.persistence.converter
+
+import jp.ijufumi.openreports.domain.models.entity.{RefreshToken => RefreshTokenModel}
+import jp.ijufumi.openreports.infrastructure.persistence.entity.{RefreshToken => RefreshTokenEntity}
+
+object RefreshTokenConverter {
+  def toDomain(entity: RefreshTokenEntity): RefreshTokenModel = {
+    RefreshTokenModel(
+      entity.id,
+      entity.memberId,
+      entity.refreshToken,
+      entity.expiredAt,
+      entity.usedAt,
+      entity.createdAt,
+      entity.updatedAt,
+      entity.versions,
+    )
+  }
+
+  def toEntity(model: RefreshTokenModel): RefreshTokenEntity = {
+    RefreshTokenEntity(
+      model.id,
+      model.memberId,
+      model.refreshToken,
+      model.expiredAt,
+      model.usedAt,
+      model.createdAt,
+      model.updatedAt,
+      model.versions,
+    )
+  }
+
+  object conversions {
+    import scala.language.implicitConversions
+
+    implicit def fromRefreshTokenEntity(entity: RefreshTokenEntity): RefreshTokenModel =
+      toDomain(entity)
+    implicit def fromRefreshTokenEntity2(
+        entity: Option[RefreshTokenEntity],
+    ): Option[RefreshTokenModel] =
+      entity.map(toDomain)
+    implicit def fromRefreshTokenEntities(entity: Seq[RefreshTokenEntity]): Seq[RefreshTokenModel] =
+      entity.map(toDomain)
+    implicit def toRefreshTokenEntity(model: RefreshTokenModel): RefreshTokenEntity =
+      toEntity(model)
+  }
+}

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/entity/RefreshToken.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/entity/RefreshToken.scala
@@ -7,6 +7,8 @@ case class RefreshToken(
     id: String,
     memberId: String,
     refreshToken: String,
+    expiredAt: Long,
+    usedAt: Option[Long] = None,
     createdAt: Long = Dates.currentTimestamp(),
     updatedAt: Long = Dates.currentTimestamp(),
     versions: Long = 1,
@@ -19,13 +21,17 @@ class RefreshTokens(tag: Tag)
     ) {
   def id = column[String]("id", O.PrimaryKey)
   def memberId = column[String]("member_id")
-  def refreshToken = column[String]("refresh_token")
+  def refreshToken = column[String]("refresh_token", O.Unique)
+  def expiredAt = column[Long]("expired_at")
+  def usedAt = column[Option[Long]]("used_at")
 
   override def * =
     (
       id,
       memberId,
       refreshToken,
+      expiredAt,
+      usedAt,
       createdAt,
       updatedAt,
       versions,

--- a/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/RefreshTokenRepositoryImpl.scala
+++ b/src/main/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/RefreshTokenRepositoryImpl.scala
@@ -1,0 +1,60 @@
+package jp.ijufumi.openreports.infrastructure.persistence.repository
+
+import scala.concurrent.Await
+import jp.ijufumi.openreports.domain.repository.RefreshTokenRepository
+import jp.ijufumi.openreports.domain.models.entity.RefreshToken
+import slick.jdbc.JdbcBackend.Database
+import slick.jdbc.PostgresProfile.api._
+import jp.ijufumi.openreports.infrastructure.persistence.converter.RefreshTokenConverter.conversions._
+
+class RefreshTokenRepositoryImpl extends RefreshTokenRepository {
+  override def getByToken(db: Database, refreshToken: String): Option[RefreshToken] = {
+    val getTokens = refreshTokenQuery
+      .filter(_.refreshToken === refreshToken)
+    val tokens = Await.result(db.run(getTokens.result), queryTimeout)
+    if (tokens.isEmpty) {
+      return None
+    }
+    Some(tokens.head)
+  }
+
+  override def register(db: Database, refreshToken: RefreshToken): Option[RefreshToken] = {
+    val register = (refreshTokenQuery += refreshToken).withPinnedSession
+    Await.result(db.run(register), queryTimeout)
+    getById(db, refreshToken.id)
+  }
+
+  override def markUsed(db: Database, refreshToken: String, usedAt: Long): Int = {
+    val query = refreshTokenQuery
+      .filter(t => t.refreshToken === refreshToken && t.usedAt.isEmpty)
+      .map(_.usedAt)
+      .update(Some(usedAt))
+      .withPinnedSession
+    Await.result(db.run(query), queryTimeout)
+  }
+
+  override def deleteByToken(db: Database, refreshToken: String): Int = {
+    val query = refreshTokenQuery.filter(_.refreshToken === refreshToken).delete.withPinnedSession
+    Await.result(db.run(query), queryTimeout)
+  }
+
+  override def deleteByMemberId(db: Database, memberId: String): Unit = {
+    val query = refreshTokenQuery.filter(_.memberId === memberId).delete.withPinnedSession
+    Await.result(db.run(query), queryTimeout)
+  }
+
+  override def deleteExpired(db: Database, now: Long): Unit = {
+    val query = refreshTokenQuery.filter(_.expiredAt < now).delete.withPinnedSession
+    Await.result(db.run(query), queryTimeout)
+  }
+
+  private def getById(db: Database, id: String): Option[RefreshToken] = {
+    val getTokens = refreshTokenQuery
+      .filter(_.id === id)
+    val tokens = Await.result(db.run(getTokens.result), queryTimeout)
+    if (tokens.isEmpty) {
+      return None
+    }
+    Some(tokens.head)
+  }
+}

--- a/src/main/scala/jp/ijufumi/openreports/presentation/controller/base/PrivateAPIServletBase.scala
+++ b/src/main/scala/jp/ijufumi/openreports/presentation/controller/base/PrivateAPIServletBase.scala
@@ -19,22 +19,19 @@ abstract class PrivateAPIServletBase(loginService: LoginUseCase)
         val refreshToken = refreshTokenHeader()
         if (refreshToken == null || refreshToken.isEmpty) {
           halt(unauthorized("API Token is invalid"))
-        } else {
-          val accessToken = loginService.generateAccessToken(refreshToken)
-          if (accessToken.isEmpty) {
-            halt(unauthorized("API Token is invalid"))
-          } else {
-            response.setHeader(Config.API_TOKEN_HEADER, accessToken.get)
-            member = loginService.verifyApiToken(accessToken.get)
-            if (member.isEmpty) {
-              halt(unauthorized("API Token is invalid"))
-            } else {
-              setMember(member.get)
-              val refreshToken = loginService.generateRefreshToken(memberId())
-              response.setHeader(Config.REFRESH_TOKEN_HEADER, refreshToken)
-            }
-          }
         }
+        val tokensOpt = loginService.refreshTokens(refreshToken)
+        if (tokensOpt.isEmpty) {
+          halt(unauthorized("API Token is invalid"))
+        }
+        val tokens = tokensOpt.get
+        member = loginService.verifyApiToken(tokens.accessToken)
+        if (member.isEmpty) {
+          halt(unauthorized("API Token is invalid"))
+        }
+        setMember(member.get)
+        response.setHeader(Config.API_TOKEN_HEADER, tokens.accessToken)
+        tokens.refreshToken.foreach(response.setHeader(Config.REFRESH_TOKEN_HEADER, _))
       } else {
         setMember(member.get)
       }

--- a/src/main/scala/jp/ijufumi/openreports/presentation/controller/base/PrivateAPIServletBase.scala
+++ b/src/main/scala/jp/ijufumi/openreports/presentation/controller/base/PrivateAPIServletBase.scala
@@ -11,6 +11,8 @@ abstract class PrivateAPIServletBase(loginService: LoginUseCase)
     with FileUploadSupport {
   configureMultipartHandling(MultipartConfig(maxFileSize = Some(Config.UPLOAD_FILE_MAX_SIZE)))
 
+  private val ATTRIBUTE_KEY_ROTATED_REFRESH_TOKEN = "rotatedRefreshToken"
+
   before() {
     if (!isOptions && !skipAuthorization()) {
       val header = authorizationHeader()
@@ -31,7 +33,10 @@ abstract class PrivateAPIServletBase(loginService: LoginUseCase)
         }
         setMember(member.get)
         response.setHeader(Config.API_TOKEN_HEADER, tokens.accessToken)
-        tokens.refreshToken.foreach(response.setHeader(Config.REFRESH_TOKEN_HEADER, _))
+        tokens.refreshToken.foreach { token =>
+          response.setHeader(Config.REFRESH_TOKEN_HEADER, token)
+          request.setAttribute(ATTRIBUTE_KEY_ROTATED_REFRESH_TOKEN, token)
+        }
       } else {
         setMember(member.get)
       }
@@ -54,6 +59,10 @@ abstract class PrivateAPIServletBase(loginService: LoginUseCase)
 
   def refreshTokenHeader(): String = {
     request.getHeader(Config.REFRESH_TOKEN_HEADER)
+  }
+
+  def rotatedRefreshToken(): Option[String] = {
+    Option(request.getAttribute(ATTRIBUTE_KEY_ROTATED_REFRESH_TOKEN)).map(_.asInstanceOf[String])
   }
 
   def workspaceId(): String = {

--- a/src/main/scala/jp/ijufumi/openreports/presentation/controller/private_/MemberServlet.scala
+++ b/src/main/scala/jp/ijufumi/openreports/presentation/controller/private_/MemberServlet.scala
@@ -20,8 +20,9 @@ class MemberServlet @Inject() (loginService: LoginUseCase, memberService: Member
   }
 
   get("/logout") {
-    val header = authorizationHeader()
-    loginService.logout(header, refreshTokenHeader())
+    val refreshTokens =
+      (Option(refreshTokenHeader()) ++ rotatedRefreshToken()).toSeq.filter(_.nonEmpty)
+    loginService.logout(memberId(), refreshTokens)
   }
 
   put("/update") {

--- a/src/main/scala/jp/ijufumi/openreports/presentation/controller/private_/MemberServlet.scala
+++ b/src/main/scala/jp/ijufumi/openreports/presentation/controller/private_/MemberServlet.scala
@@ -21,7 +21,7 @@ class MemberServlet @Inject() (loginService: LoginUseCase, memberService: Member
 
   get("/logout") {
     val header = authorizationHeader()
-    loginService.logout(header)
+    loginService.logout(header, refreshTokenHeader())
   }
 
   put("/update") {

--- a/src/main/scala/jp/ijufumi/openreports/presentation/controller/public_/LoginServlet.scala
+++ b/src/main/scala/jp/ijufumi/openreports/presentation/controller/public_/LoginServlet.scala
@@ -51,20 +51,8 @@ class LoginServlet @Inject() (loginService: LoginUseCase)
   }
 
   def setTokens(memberId: String): Unit = {
-    val refreshToken = generateRefreshToken(memberId)
-    generateAccessToken(refreshToken)
-  }
-
-  def generateRefreshToken(memberId: String): String = {
-    val refreshToken = loginService.generateRefreshToken(memberId)
-    response.setHeader(Config.REFRESH_TOKEN_HEADER, refreshToken)
-    refreshToken
-  }
-
-  def generateAccessToken(refreshToken: String): Unit = {
-    loginService.generateAccessToken(refreshToken) match {
-      case Some(token) => response.setHeader(Config.API_TOKEN_HEADER, token)
-      case None        => logger.warn("Failed to generate access token from refresh token")
-    }
+    val tokens = loginService.generateTokens(memberId)
+    response.setHeader(Config.API_TOKEN_HEADER, tokens.accessToken)
+    tokens.refreshToken.foreach(response.setHeader(Config.REFRESH_TOKEN_HEADER, _))
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/usecase/interactor/LoginInteractor.scala
+++ b/src/main/scala/jp/ijufumi/openreports/usecase/interactor/LoginInteractor.scala
@@ -4,10 +4,18 @@ import jp.ijufumi.openreports.usecase.port.input.{LoginUseCase, WorkspaceUseCase
 import com.google.inject.{Inject, Singleton}
 import jp.ijufumi.openreports.configs.Config
 import jp.ijufumi.openreports.domain.port.{AppConfigPort, CacheKeys, CachePort, GoogleAuthPort}
-import jp.ijufumi.openreports.utils.{Hash, IDs, Logging, Strings}
-import jp.ijufumi.openreports.domain.repository.{MemberRepository, WorkspaceRepository}
+import jp.ijufumi.openreports.utils.{Dates, Hash, IDs, Logging, Strings}
+import jp.ijufumi.openreports.domain.repository.{
+  MemberRepository,
+  RefreshTokenRepository,
+  WorkspaceRepository,
+}
 import jp.ijufumi.openreports.usecase.port.input.param.{GoogleLoginInput, LoginInput}
-import jp.ijufumi.openreports.domain.models.entity.{Member => MemberModel}
+import jp.ijufumi.openreports.domain.models.entity.{
+  Member => MemberModel,
+  RefreshToken => RefreshTokenModel,
+}
+import jp.ijufumi.openreports.domain.models.value.AuthTokens
 import slick.jdbc.JdbcBackend.Database
 
 @Singleton
@@ -15,6 +23,7 @@ class LoginInteractor @Inject() (
     db: Database,
     memberRepository: MemberRepository,
     workspaceRepository: WorkspaceRepository,
+    refreshTokenRepository: RefreshTokenRepository,
     googleAuthPort: GoogleAuthPort,
     workspaceService: WorkspaceUseCase,
     cachePort: CachePort,
@@ -39,12 +48,20 @@ class LoginInteractor @Inject() (
     makeResponse(member)
   }
 
-  override def logout(authorizationHeader: String): Unit = {
+  override def logout(authorizationHeader: String, refreshToken: String): Unit = {
     val memberOpt = getMember(authorizationHeader)
     if (memberOpt.isEmpty) {
       return
     }
-    cachePort.remove(CacheKeys.ApiToken, memberOpt.get.id)
+    if (refreshToken == null || refreshToken.isEmpty) {
+      return
+    }
+    val tokenMemberId = Hash.extractIdFromJWT(refreshToken)
+    if (tokenMemberId != memberOpt.get.id) {
+      logger.info("refresh token does not belong to the member")
+      return
+    }
+    refreshTokenRepository.deleteByToken(db, Hash.hmacSha256(refreshToken))
   }
 
   override def verifyAuthorizationHeader(authorizationHeader: String): Option[MemberModel] = {
@@ -147,20 +164,61 @@ class LoginInteractor @Inject() (
     }
   }
 
-  def generateAccessToken(token: String): Option[String] = {
-    val memberIdOpt = cachePort.get(CacheKeys.ApiToken, token)
-    if (memberIdOpt.isEmpty) {
+  override def generateTokens(memberId: String): AuthTokens = {
+    val accessToken = Hash.generateJWT(memberId, appConfig.accessTokenExpirationSec)
+    val refreshToken = Hash.generateJWT(memberId, appConfig.refreshTokenExpirationSec)
+    val now = Dates.currentTimestamp()
+    refreshTokenRepository.deleteExpired(db, now)
+    refreshTokenRepository.register(
+      db,
+      RefreshTokenModel(
+        id = IDs.ulid(),
+        memberId = memberId,
+        refreshToken = Hash.hmacSha256(refreshToken),
+        expiredAt = now + appConfig.refreshTokenExpirationSec.toLong * 1000,
+      ),
+    )
+    AuthTokens(accessToken, Some(refreshToken))
+  }
+
+  override def refreshTokens(refreshToken: String): Option[AuthTokens] = {
+    val memberId = Hash.extractIdFromJWT(refreshToken)
+    if (memberId == null || memberId.isEmpty) {
+      logger.info("refresh token is invalid")
       return None
     }
 
-    val apiToken = Hash.generateJWT(memberIdOpt.get, appConfig.accessTokenExpirationSec)
-    Some(apiToken)
-  }
+    val hashedToken = Hash.hmacSha256(refreshToken)
+    val storedTokenOpt = refreshTokenRepository.getByToken(db, hashedToken)
+    if (storedTokenOpt.isEmpty) {
+      logger.info("refresh token is not registered")
+      return None
+    }
 
-  override def generateRefreshToken(memberId: String): String = {
-    val token = Hash.generateJWT(memberId, appConfig.refreshTokenExpirationSec)
-    cachePort.put(CacheKeys.ApiToken, memberId, token)(appConfig.refreshTokenExpirationSec.toLong)
-    token
+    val storedToken = storedTokenOpt.get
+    val now = Dates.currentTimestamp()
+    if (storedToken.memberId != memberId || storedToken.expiredAt < now) {
+      refreshTokenRepository.deleteByToken(db, hashedToken)
+      logger.info("refresh token is expired or member does not match")
+      return None
+    }
+
+    // rotate: only the request that marks the token as used can issue a new refresh token,
+    // so concurrent refreshes with the same token produce at most one new pair
+    val claimed = refreshTokenRepository.markUsed(db, hashedToken, now)
+    if (claimed > 0) {
+      return Some(generateTokens(memberId))
+    }
+
+    // late concurrent request: reissue only an access token within the grace period
+    val usedTokenOpt = refreshTokenRepository.getByToken(db, hashedToken)
+    val withinGracePeriod =
+      usedTokenOpt.flatMap(_.usedAt).exists(now - _ <= Config.REFRESH_TOKEN_GRACE_PERIOD_MILLIS)
+    if (!withinGracePeriod) {
+      logger.info("refresh token was already used")
+      return None
+    }
+    Some(AuthTokens(Hash.generateJWT(memberId, appConfig.accessTokenExpirationSec), None))
   }
 
   private def makeResponse(member: MemberModel): Option[MemberModel] = {

--- a/src/main/scala/jp/ijufumi/openreports/usecase/interactor/LoginInteractor.scala
+++ b/src/main/scala/jp/ijufumi/openreports/usecase/interactor/LoginInteractor.scala
@@ -48,20 +48,17 @@ class LoginInteractor @Inject() (
     makeResponse(member)
   }
 
-  override def logout(authorizationHeader: String, refreshToken: String): Unit = {
-    val memberOpt = getMember(authorizationHeader)
-    if (memberOpt.isEmpty) {
-      return
+  override def logout(memberId: String, refreshTokens: Seq[String]): Unit = {
+    refreshTokens.foreach { refreshToken =>
+      if (refreshToken != null && refreshToken.nonEmpty) {
+        val tokenMemberId = Hash.extractIdFromJWT(refreshToken)
+        if (tokenMemberId == memberId) {
+          refreshTokenRepository.deleteByToken(db, Hash.hmacSha256(refreshToken))
+        } else {
+          logger.info("refresh token does not belong to the member")
+        }
+      }
     }
-    if (refreshToken == null || refreshToken.isEmpty) {
-      return
-    }
-    val tokenMemberId = Hash.extractIdFromJWT(refreshToken)
-    if (tokenMemberId != memberOpt.get.id) {
-      logger.info("refresh token does not belong to the member")
-      return
-    }
-    refreshTokenRepository.deleteByToken(db, Hash.hmacSha256(refreshToken))
   }
 
   override def verifyAuthorizationHeader(authorizationHeader: String): Option[MemberModel] = {
@@ -238,17 +235,5 @@ class LoginInteractor @Inject() (
       return None
     }
     Some(tokenMatcher.group(1))
-  }
-
-  private def getMember(authorizationHeader: String): Option[MemberModel] = {
-    val apiToken = getApiToken(authorizationHeader)
-    if (apiToken.isEmpty) {
-      return None
-    }
-    val memberId = Hash.extractIdFromJWT(apiToken.get)
-    if (memberId == "") {
-      return None
-    }
-    memberRepository.getById(db, memberId)
   }
 }

--- a/src/main/scala/jp/ijufumi/openreports/usecase/port/input/LoginUseCase.scala
+++ b/src/main/scala/jp/ijufumi/openreports/usecase/port/input/LoginUseCase.scala
@@ -7,7 +7,7 @@ import jp.ijufumi.openreports.domain.models.value.AuthTokens
 trait LoginUseCase {
   def login(input: LoginInput): Option[MemberModel]
 
-  def logout(authorizationHeader: String, refreshToken: String): Unit
+  def logout(memberId: String, refreshTokens: Seq[String]): Unit
 
   def verifyAuthorizationHeader(authorizationHeader: String): Option[MemberModel]
 

--- a/src/main/scala/jp/ijufumi/openreports/usecase/port/input/LoginUseCase.scala
+++ b/src/main/scala/jp/ijufumi/openreports/usecase/port/input/LoginUseCase.scala
@@ -2,11 +2,12 @@ package jp.ijufumi.openreports.usecase.port.input
 
 import jp.ijufumi.openreports.usecase.port.input.param.{GoogleLoginInput, LoginInput}
 import jp.ijufumi.openreports.domain.models.entity.{Member => MemberModel}
+import jp.ijufumi.openreports.domain.models.value.AuthTokens
 
 trait LoginUseCase {
   def login(input: LoginInput): Option[MemberModel]
 
-  def logout(apiToken: String): Unit
+  def logout(authorizationHeader: String, refreshToken: String): Unit
 
   def verifyAuthorizationHeader(authorizationHeader: String): Option[MemberModel]
 
@@ -18,7 +19,7 @@ trait LoginUseCase {
 
   def loginWithGoogle(input: GoogleLoginInput): Option[MemberModel]
 
-  def generateAccessToken(refreshToken: String): Option[String]
+  def generateTokens(memberId: String): AuthTokens
 
-  def generateRefreshToken(memberId: String): String
+  def refreshTokens(refreshToken: String): Option[AuthTokens]
 }

--- a/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/RefreshTokenRepositoryImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/infrastructure/persistence/repository/RefreshTokenRepositoryImplSpec.scala
@@ -1,0 +1,147 @@
+package jp.ijufumi.openreports.infrastructure.persistence.repository
+
+import jp.ijufumi.openreports.domain.models.entity.RefreshToken
+import jp.ijufumi.openreports.infrastructure.persistence.H2DatabaseHelper
+import jp.ijufumi.openreports.utils.{Dates, IDs}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import slick.jdbc.JdbcBackend.Database
+
+class RefreshTokenRepositoryImplSpec
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach {
+
+  var db: Database = _
+  val repository = new RefreshTokenRepositoryImpl()
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    db = H2DatabaseHelper.createDatabase("refresh_token_test")
+    H2DatabaseHelper.createSchema(db, refreshTokenQuery)
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    H2DatabaseHelper.closeDatabase(db)
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    H2DatabaseHelper.truncateTables(db, refreshTokenQuery)
+  }
+
+  private def newToken(
+      memberId: String = "member-1",
+      refreshToken: String = IDs.ulid(),
+      expiredAt: Long = Dates.currentTimestamp() + 3600 * 1000,
+  ): RefreshToken = {
+    RefreshToken(
+      id = IDs.ulid(),
+      memberId = memberId,
+      refreshToken = refreshToken,
+      expiredAt = expiredAt,
+    )
+  }
+
+  "register" should "create new refresh token and return it" in {
+    val token = newToken()
+
+    val result = repository.register(db, token)
+
+    result should be(defined)
+    result.get.id should equal(token.id)
+    result.get.memberId should equal(token.memberId)
+    result.get.refreshToken should equal(token.refreshToken)
+    result.get.expiredAt should equal(token.expiredAt)
+  }
+
+  "getByToken" should "return refresh token when exists" in {
+    val token = newToken()
+    repository.register(db, token)
+
+    val result = repository.getByToken(db, token.refreshToken)
+
+    result should be(defined)
+    result.get.id should equal(token.id)
+  }
+
+  it should "return None when refresh token doesn't exist" in {
+    val result = repository.getByToken(db, "non-existent-token")
+
+    result should be(None)
+  }
+
+  "markUsed" should "mark the refresh token as used and return updated count" in {
+    val token = newToken()
+    repository.register(db, token)
+    val usedAt = Dates.currentTimestamp()
+
+    val updated = repository.markUsed(db, token.refreshToken, usedAt)
+
+    updated should equal(1)
+    repository.getByToken(db, token.refreshToken).get.usedAt should equal(Some(usedAt))
+  }
+
+  it should "return 0 when refresh token is already used" in {
+    val token = newToken()
+    repository.register(db, token)
+    repository.markUsed(db, token.refreshToken, Dates.currentTimestamp())
+
+    val updated = repository.markUsed(db, token.refreshToken, Dates.currentTimestamp())
+
+    updated should equal(0)
+  }
+
+  it should "return 0 when refresh token doesn't exist" in {
+    val updated = repository.markUsed(db, "non-existent-token", Dates.currentTimestamp())
+
+    updated should equal(0)
+  }
+
+  "deleteByToken" should "delete the refresh token and return deleted count" in {
+    val token = newToken()
+    repository.register(db, token)
+
+    val deleted = repository.deleteByToken(db, token.refreshToken)
+
+    deleted should equal(1)
+    repository.getByToken(db, token.refreshToken) should be(None)
+  }
+
+  it should "return 0 when refresh token doesn't exist" in {
+    val deleted = repository.deleteByToken(db, "non-existent-token")
+
+    deleted should equal(0)
+  }
+
+  "deleteByMemberId" should "delete all refresh tokens of the member" in {
+    val token1 = newToken(memberId = "member-1")
+    val token2 = newToken(memberId = "member-1")
+    val token3 = newToken(memberId = "member-2")
+    repository.register(db, token1)
+    repository.register(db, token2)
+    repository.register(db, token3)
+
+    repository.deleteByMemberId(db, "member-1")
+
+    repository.getByToken(db, token1.refreshToken) should be(None)
+    repository.getByToken(db, token2.refreshToken) should be(None)
+    repository.getByToken(db, token3.refreshToken) should be(defined)
+  }
+
+  "deleteExpired" should "delete only expired refresh tokens" in {
+    val now = Dates.currentTimestamp()
+    val expiredToken = newToken(expiredAt = now - 1000)
+    val validToken = newToken(expiredAt = now + 3600 * 1000)
+    repository.register(db, expiredToken)
+    repository.register(db, validToken)
+
+    repository.deleteExpired(db, now)
+
+    repository.getByToken(db, expiredToken.refreshToken) should be(None)
+    repository.getByToken(db, validToken.refreshToken) should be(defined)
+  }
+}

--- a/src/test/scala/jp/ijufumi/openreports/presentation/controller/private_/MemberServletSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/presentation/controller/private_/MemberServletSpec.scala
@@ -56,11 +56,15 @@ class MemberServletSpec extends ScalatraFunSuite with MockFactory {
     val member = MemberModel("member-id", None, "test@example.com", "", "Test User", 0, 0)
     (loginService.verifyAuthorizationHeader _).expects("api-token").returns(Some(member))
     (loginService.verifyWorkspaceId _).expects(member.id, "workspace-id").returns(true)
-    (loginService.logout _).expects("api-token").returns(())
+    (loginService.logout _).expects("api-token", "refresh-token").returns(())
 
     get(
       "/logout",
-      headers = Map("Authorization" -> "api-token", "X-Workspace-Id" -> "workspace-id"),
+      headers = Map(
+        "Authorization" -> "api-token",
+        "X-Workspace-Id" -> "workspace-id",
+        "X-Refresh-Token" -> "refresh-token",
+      ),
     ) {
       status should equal(200)
     }

--- a/src/test/scala/jp/ijufumi/openreports/presentation/controller/private_/MemberServletSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/presentation/controller/private_/MemberServletSpec.scala
@@ -56,7 +56,7 @@ class MemberServletSpec extends ScalatraFunSuite with MockFactory {
     val member = MemberModel("member-id", None, "test@example.com", "", "Test User", 0, 0)
     (loginService.verifyAuthorizationHeader _).expects("api-token").returns(Some(member))
     (loginService.verifyWorkspaceId _).expects(member.id, "workspace-id").returns(true)
-    (loginService.logout _).expects("api-token", "refresh-token").returns(())
+    (loginService.logout _).expects(member.id, Seq("refresh-token")).returns(())
 
     get(
       "/logout",

--- a/src/test/scala/jp/ijufumi/openreports/presentation/controller/public_/LoginServletSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/presentation/controller/public_/LoginServletSpec.scala
@@ -1,6 +1,7 @@
 package jp.ijufumi.openreports.presentation.controller.public_
 
 import jp.ijufumi.openreports.domain.models.entity.{Member => MemberModel}
+import jp.ijufumi.openreports.domain.models.value.AuthTokens
 import jp.ijufumi.openreports.usecase.port.input.LoginUseCase
 import jp.ijufumi.openreports.usecase.port.input.param.LoginInput
 import org.scalamock.scalatest.MockFactory
@@ -17,10 +18,13 @@ class LoginServletSpec extends ScalatraFunSuite with MockFactory {
     val input = LoginInput("test@test.com", "password")
     val member = MemberModel("id", None, "email@email.com", "", "name", 0, 0)
     (loginService.login _).expects(input).returns(Some(member))
-    (loginService.generateRefreshToken _).expects(member.id).returns("refresh_token")
-    (loginService.generateAccessToken _).expects("refresh_token").returns(Some("access_token"))
+    (loginService.generateTokens _)
+      .expects(member.id)
+      .returns(AuthTokens("access_token", Some("refresh_token")))
     post("/password", write(input)) {
       status should equal(200)
+      header("X-Api-Token") should equal("access_token")
+      header("X-Refresh-Token") should equal("refresh_token")
     }
   }
 }

--- a/src/test/scala/jp/ijufumi/openreports/usecase/interactor/LoginServiceImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/usecase/interactor/LoginServiceImplSpec.scala
@@ -281,50 +281,28 @@ class LoginInteractorSpec extends AnyFlatSpec with MockitoSugar {
     verify(f.refreshTokenRepository).deleteByToken(f.db, hashedToken)
   }
 
-  "logout" should "delete only the refresh token of the session" in {
+  "logout" should "delete all refresh tokens of the session" in {
     val f = new Fixture
     val memberId = "member-1"
-    val member = Member(
-      id = memberId,
-      googleId = None,
-      email = "test@test.com",
-      password = "",
-      name = "test",
-      createdAt = 0,
-      updatedAt = 0,
-    )
-    val apiToken = Hash.generateJWT(memberId, 600)
-    val refreshToken = Hash.generateJWT(memberId, 3600)
-
-    when(f.memberRepository.getById(f.db, memberId)).thenReturn(Some(member))
+    // distinct expirations so the two JWTs are not identical
+    val headerToken = Hash.generateJWT(memberId, 3600)
+    val rotatedToken = Hash.generateJWT(memberId, 7200)
 
     // when
-    f.loginService.logout(s"Bearer $apiToken", refreshToken)
+    f.loginService.logout(memberId, Seq(headerToken, rotatedToken))
 
     // then
-    verify(f.refreshTokenRepository).deleteByToken(f.db, Hash.hmacSha256(refreshToken))
+    verify(f.refreshTokenRepository).deleteByToken(f.db, Hash.hmacSha256(headerToken))
+    verify(f.refreshTokenRepository).deleteByToken(f.db, Hash.hmacSha256(rotatedToken))
     verify(f.refreshTokenRepository, never()).deleteByMemberId(f.db, memberId)
   }
 
   it should "not delete refresh token if it belongs to another member" in {
     val f = new Fixture
-    val memberId = "member-1"
-    val member = Member(
-      id = memberId,
-      googleId = None,
-      email = "test@test.com",
-      password = "",
-      name = "test",
-      createdAt = 0,
-      updatedAt = 0,
-    )
-    val apiToken = Hash.generateJWT(memberId, 600)
     val refreshToken = Hash.generateJWT("member-2", 3600)
 
-    when(f.memberRepository.getById(f.db, memberId)).thenReturn(Some(member))
-
     // when
-    f.loginService.logout(s"Bearer $apiToken", refreshToken)
+    f.loginService.logout("member-1", Seq(refreshToken))
 
     // then
     verify(f.refreshTokenRepository, never()).deleteByToken(
@@ -333,24 +311,11 @@ class LoginInteractorSpec extends AnyFlatSpec with MockitoSugar {
     )
   }
 
-  it should "do nothing if refresh token is missing" in {
+  it should "do nothing if refresh tokens are empty" in {
     val f = new Fixture
-    val memberId = "member-1"
-    val member = Member(
-      id = memberId,
-      googleId = None,
-      email = "test@test.com",
-      password = "",
-      name = "test",
-      createdAt = 0,
-      updatedAt = 0,
-    )
-    val apiToken = Hash.generateJWT(memberId, 600)
-
-    when(f.memberRepository.getById(f.db, memberId)).thenReturn(Some(member))
 
     // when
-    f.loginService.logout(s"Bearer $apiToken", null)
+    f.loginService.logout("member-1", Seq.empty)
 
     // then
     verify(f.refreshTokenRepository, never()).deleteByToken(

--- a/src/test/scala/jp/ijufumi/openreports/usecase/interactor/LoginServiceImplSpec.scala
+++ b/src/test/scala/jp/ijufumi/openreports/usecase/interactor/LoginServiceImplSpec.scala
@@ -1,11 +1,16 @@
 package jp.ijufumi.openreports.usecase.interactor
 
-import jp.ijufumi.openreports.domain.models.entity.Member
+import jp.ijufumi.openreports.domain.models.entity.{Member, RefreshToken}
 import jp.ijufumi.openreports.domain.port.{AppConfigPort, CachePort, GoogleAuthPort}
-import jp.ijufumi.openreports.domain.repository.{MemberRepository, WorkspaceRepository}
+import jp.ijufumi.openreports.domain.repository.{
+  MemberRepository,
+  RefreshTokenRepository,
+  WorkspaceRepository,
+}
 import jp.ijufumi.openreports.usecase.port.input.WorkspaceUseCase
 import jp.ijufumi.openreports.usecase.port.input.param.LoginInput
-import jp.ijufumi.openreports.utils.Hash
+import jp.ijufumi.openreports.utils.{Dates, Hash}
+import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -13,11 +18,11 @@ import slick.jdbc.JdbcBackend.Database
 
 class LoginInteractorSpec extends AnyFlatSpec with MockitoSugar {
 
-  "login" should "return Member if email and password are correct" in {
-    // mock
+  private class Fixture {
     val db = mock[Database]
     val memberRepository = mock[MemberRepository]
     val workspaceRepository = mock[WorkspaceRepository]
+    val refreshTokenRepository = mock[RefreshTokenRepository]
     val googleAuthPort = mock[GoogleAuthPort]
     val workspaceService = mock[WorkspaceUseCase]
     val cachePort = mock[CachePort]
@@ -28,11 +33,16 @@ class LoginInteractorSpec extends AnyFlatSpec with MockitoSugar {
         db,
         memberRepository,
         workspaceRepository,
+        refreshTokenRepository,
         googleAuthPort,
         workspaceService,
         cachePort,
         appConfig,
       )
+  }
+
+  "login" should "return Member if email and password are correct" in {
+    val f = new Fixture
 
     val email = "test@test.com"
     val password = "password"
@@ -47,11 +57,11 @@ class LoginInteractorSpec extends AnyFlatSpec with MockitoSugar {
       updatedAt = 0,
     )
 
-    when(memberRepository.getMemberByEmail(db, email)).thenReturn(Some(member))
-    when(workspaceRepository.getsByMemberId(db, member.id)).thenReturn(Seq.empty)
+    when(f.memberRepository.getMemberByEmail(f.db, email)).thenReturn(Some(member))
+    when(f.workspaceRepository.getsByMemberId(f.db, member.id)).thenReturn(Seq.empty)
 
     // when
-    val actual = loginService.login(input)
+    val actual = f.loginService.login(input)
 
     // then
     assert(actual.isDefined)
@@ -59,59 +69,23 @@ class LoginInteractorSpec extends AnyFlatSpec with MockitoSugar {
   }
 
   it should "return None if email does not exist" in {
-    // mock
-    val db = mock[Database]
-    val memberRepository = mock[MemberRepository]
-    val workspaceRepository = mock[WorkspaceRepository]
-    val googleAuthPort = mock[GoogleAuthPort]
-    val workspaceService = mock[WorkspaceUseCase]
-    val cachePort = mock[CachePort]
-    val appConfig = mock[AppConfigPort]
-
-    val loginService =
-      new LoginInteractor(
-        db,
-        memberRepository,
-        workspaceRepository,
-        googleAuthPort,
-        workspaceService,
-        cachePort,
-        appConfig,
-      )
+    val f = new Fixture
 
     val email = "test@test.com"
     val password = "password"
     val input = LoginInput(email, password)
 
-    when(memberRepository.getMemberByEmail(db, email)).thenReturn(None)
+    when(f.memberRepository.getMemberByEmail(f.db, email)).thenReturn(None)
 
     // when
-    val actual = loginService.login(input)
+    val actual = f.loginService.login(input)
 
     // then
     assert(actual.isEmpty)
   }
 
   it should "return None if password does not match" in {
-    // mock
-    val db = mock[Database]
-    val memberRepository = mock[MemberRepository]
-    val workspaceRepository = mock[WorkspaceRepository]
-    val googleAuthPort = mock[GoogleAuthPort]
-    val workspaceService = mock[WorkspaceUseCase]
-    val cachePort = mock[CachePort]
-    val appConfig = mock[AppConfigPort]
-
-    val loginService =
-      new LoginInteractor(
-        db,
-        memberRepository,
-        workspaceRepository,
-        googleAuthPort,
-        workspaceService,
-        cachePort,
-        appConfig,
-      )
+    val f = new Fixture
 
     val email = "test@test.com"
     val password = "password"
@@ -127,12 +101,261 @@ class LoginInteractorSpec extends AnyFlatSpec with MockitoSugar {
       updatedAt = 0,
     )
 
-    when(memberRepository.getMemberByEmail(db, email)).thenReturn(Some(member))
+    when(f.memberRepository.getMemberByEmail(f.db, email)).thenReturn(Some(member))
 
     // when
-    val actual = loginService.login(input)
+    val actual = f.loginService.login(input)
 
     // then
     assert(actual.isEmpty)
+  }
+
+  "generateTokens" should "return tokens and register refresh token" in {
+    val f = new Fixture
+    val memberId = "member-1"
+
+    when(f.appConfig.accessTokenExpirationSec).thenReturn(Integer.valueOf(600))
+    when(f.appConfig.refreshTokenExpirationSec).thenReturn(Integer.valueOf(3600))
+
+    // when
+    val tokens = f.loginService.generateTokens(memberId)
+
+    // then
+    assert(Hash.extractIdFromJWT(tokens.accessToken) == memberId)
+    assert(tokens.refreshToken.isDefined)
+    assert(Hash.extractIdFromJWT(tokens.refreshToken.get) == memberId)
+    verify(f.refreshTokenRepository).deleteExpired(
+      ArgumentMatchers.eq(f.db),
+      ArgumentMatchers.anyLong(),
+    )
+    verify(f.refreshTokenRepository).register(
+      ArgumentMatchers.eq(f.db),
+      ArgumentMatchers.any[RefreshToken](),
+    )
+  }
+
+  "refreshTokens" should "return new tokens and rotate refresh token" in {
+    val f = new Fixture
+    val memberId = "member-1"
+
+    when(f.appConfig.accessTokenExpirationSec).thenReturn(Integer.valueOf(600))
+    when(f.appConfig.refreshTokenExpirationSec).thenReturn(Integer.valueOf(3600))
+
+    val refreshToken = Hash.generateJWT(memberId, 3600)
+    val hashedToken = Hash.hmacSha256(refreshToken)
+    val storedToken = RefreshToken(
+      id = "token-1",
+      memberId = memberId,
+      refreshToken = hashedToken,
+      expiredAt = Dates.currentTimestamp() + 3600 * 1000,
+    )
+
+    when(f.refreshTokenRepository.getByToken(f.db, hashedToken)).thenReturn(Some(storedToken))
+    when(
+      f.refreshTokenRepository.markUsed(
+        ArgumentMatchers.eq(f.db),
+        ArgumentMatchers.eq(hashedToken),
+        ArgumentMatchers.anyLong(),
+      ),
+    ).thenReturn(1)
+
+    // when
+    val actual = f.loginService.refreshTokens(refreshToken)
+
+    // then
+    assert(actual.isDefined)
+    assert(Hash.extractIdFromJWT(actual.get.accessToken) == memberId)
+    assert(actual.get.refreshToken.isDefined)
+    assert(Hash.extractIdFromJWT(actual.get.refreshToken.get) == memberId)
+  }
+
+  it should "reissue only access token if token was already used within grace period" in {
+    val f = new Fixture
+    val memberId = "member-1"
+    val refreshToken = Hash.generateJWT(memberId, 3600)
+    val hashedToken = Hash.hmacSha256(refreshToken)
+    val usedToken = RefreshToken(
+      id = "token-1",
+      memberId = memberId,
+      refreshToken = hashedToken,
+      expiredAt = Dates.currentTimestamp() + 3600 * 1000,
+      usedAt = Some(Dates.currentTimestamp() - 1000),
+    )
+
+    when(f.appConfig.accessTokenExpirationSec).thenReturn(Integer.valueOf(600))
+    when(f.refreshTokenRepository.getByToken(f.db, hashedToken)).thenReturn(Some(usedToken))
+    // another request already used the token
+    when(
+      f.refreshTokenRepository.markUsed(
+        ArgumentMatchers.eq(f.db),
+        ArgumentMatchers.eq(hashedToken),
+        ArgumentMatchers.anyLong(),
+      ),
+    ).thenReturn(0)
+
+    // when
+    val actual = f.loginService.refreshTokens(refreshToken)
+
+    // then
+    assert(actual.isDefined)
+    assert(Hash.extractIdFromJWT(actual.get.accessToken) == memberId)
+    assert(actual.get.refreshToken.isEmpty)
+    verify(f.refreshTokenRepository, never()).register(
+      ArgumentMatchers.eq(f.db),
+      ArgumentMatchers.any[RefreshToken](),
+    )
+  }
+
+  it should "return None if token was already used and grace period has passed" in {
+    val f = new Fixture
+    val memberId = "member-1"
+    val refreshToken = Hash.generateJWT(memberId, 3600)
+    val hashedToken = Hash.hmacSha256(refreshToken)
+    val usedToken = RefreshToken(
+      id = "token-1",
+      memberId = memberId,
+      refreshToken = hashedToken,
+      expiredAt = Dates.currentTimestamp() + 3600 * 1000,
+      usedAt = Some(Dates.currentTimestamp() - 10000),
+    )
+
+    when(f.refreshTokenRepository.getByToken(f.db, hashedToken)).thenReturn(Some(usedToken))
+    when(
+      f.refreshTokenRepository.markUsed(
+        ArgumentMatchers.eq(f.db),
+        ArgumentMatchers.eq(hashedToken),
+        ArgumentMatchers.anyLong(),
+      ),
+    ).thenReturn(0)
+
+    // when
+    val actual = f.loginService.refreshTokens(refreshToken)
+
+    // then
+    assert(actual.isEmpty)
+  }
+
+  it should "return None if refresh token is not a valid JWT" in {
+    val f = new Fixture
+
+    // when
+    val actual = f.loginService.refreshTokens("invalid-token")
+
+    // then
+    assert(actual.isEmpty)
+  }
+
+  it should "return None if refresh token is not registered" in {
+    val f = new Fixture
+    val refreshToken = Hash.generateJWT("member-1", 3600)
+
+    when(f.refreshTokenRepository.getByToken(f.db, Hash.hmacSha256(refreshToken)))
+      .thenReturn(None)
+
+    // when
+    val actual = f.loginService.refreshTokens(refreshToken)
+
+    // then
+    assert(actual.isEmpty)
+  }
+
+  it should "return None and delete token if refresh token is expired" in {
+    val f = new Fixture
+    val memberId = "member-1"
+    val refreshToken = Hash.generateJWT(memberId, 3600)
+    val hashedToken = Hash.hmacSha256(refreshToken)
+    val storedToken = RefreshToken(
+      id = "token-1",
+      memberId = memberId,
+      refreshToken = hashedToken,
+      expiredAt = Dates.currentTimestamp() - 1000,
+    )
+
+    when(f.refreshTokenRepository.getByToken(f.db, hashedToken)).thenReturn(Some(storedToken))
+
+    // when
+    val actual = f.loginService.refreshTokens(refreshToken)
+
+    // then
+    assert(actual.isEmpty)
+    verify(f.refreshTokenRepository).deleteByToken(f.db, hashedToken)
+  }
+
+  "logout" should "delete only the refresh token of the session" in {
+    val f = new Fixture
+    val memberId = "member-1"
+    val member = Member(
+      id = memberId,
+      googleId = None,
+      email = "test@test.com",
+      password = "",
+      name = "test",
+      createdAt = 0,
+      updatedAt = 0,
+    )
+    val apiToken = Hash.generateJWT(memberId, 600)
+    val refreshToken = Hash.generateJWT(memberId, 3600)
+
+    when(f.memberRepository.getById(f.db, memberId)).thenReturn(Some(member))
+
+    // when
+    f.loginService.logout(s"Bearer $apiToken", refreshToken)
+
+    // then
+    verify(f.refreshTokenRepository).deleteByToken(f.db, Hash.hmacSha256(refreshToken))
+    verify(f.refreshTokenRepository, never()).deleteByMemberId(f.db, memberId)
+  }
+
+  it should "not delete refresh token if it belongs to another member" in {
+    val f = new Fixture
+    val memberId = "member-1"
+    val member = Member(
+      id = memberId,
+      googleId = None,
+      email = "test@test.com",
+      password = "",
+      name = "test",
+      createdAt = 0,
+      updatedAt = 0,
+    )
+    val apiToken = Hash.generateJWT(memberId, 600)
+    val refreshToken = Hash.generateJWT("member-2", 3600)
+
+    when(f.memberRepository.getById(f.db, memberId)).thenReturn(Some(member))
+
+    // when
+    f.loginService.logout(s"Bearer $apiToken", refreshToken)
+
+    // then
+    verify(f.refreshTokenRepository, never()).deleteByToken(
+      ArgumentMatchers.eq(f.db),
+      ArgumentMatchers.anyString(),
+    )
+  }
+
+  it should "do nothing if refresh token is missing" in {
+    val f = new Fixture
+    val memberId = "member-1"
+    val member = Member(
+      id = memberId,
+      googleId = None,
+      email = "test@test.com",
+      password = "",
+      name = "test",
+      createdAt = 0,
+      updatedAt = 0,
+    )
+    val apiToken = Hash.generateJWT(memberId, 600)
+
+    when(f.memberRepository.getById(f.db, memberId)).thenReturn(Some(member))
+
+    // when
+    f.loginService.logout(s"Bearer $apiToken", null)
+
+    // then
+    verify(f.refreshTokenRepository, never()).deleteByToken(
+      ArgumentMatchers.eq(f.db),
+      ArgumentMatchers.anyString(),
+    )
   }
 }


### PR DESCRIPTION
## 概要

リフレッシュトークンを DB(`refresh_tokens` テーブル)で永続化し、access_token / refresh_token の発行・検証・ローテーション・失効の一連の機能を実装しました。従来の Redis キャッシュベースの実装(logout が実質無効だったバグ含む)を置き換えます。

## 変更内容

- `refresh_tokens` テーブルを追加(マイグレーション V000002)。トークンは HMAC-SHA256 ハッシュで保存し、`expired_at` / `used_at` を保持
- ログイン時(`/login/password`, `/login/google`)に access_token / refresh_token ペアを発行し、`X-Api-Token` / `X-Refresh-Token` ヘッダーで返却
- リフレッシュ時のトークンローテーション: `used_at IS NULL` 条件付き UPDATE の件数で排他し、新しい refresh_token を発行できるのは最初の 1 リクエストのみ
- 同時リフレッシュの後続リクエストは、使用から 5 秒の猶予期間内なら access_token のみ再発行(`REFRESH_TOKEN_GRACE_PERIOD_SEC`、デフォルト 5 秒)。超過後は 401
- ログアウトは `X-Refresh-Token` ヘッダーで渡されたそのセッションのトークンのみ削除(本人のトークンであることを JWT で検証)
- `RefreshTokenRepository`(trait / Impl / Converter)、`AuthTokens` 値オブジェクトを追加し、Guice に登録
- テスト追加・更新: リポジトリ(H2)/ インタラクター / サーブレット(全 641 件成功)

※ デプロイ時は `task migrateUp`(または `sbt flywayMigrate`)によるマイグレーション適用が必要です。

## 関連Issue

なし

## Claude レビュー観点(PR固有)

<!-- REVIEW_FOCUS -->
- 同時リフレッシュ時の排他制御(`markUsed` の UPDATE 件数による判定)に競合の抜けがないか
- リフレッシュトークンのローテーションと 5 秒猶予期間の実装がセキュリティ上問題ないか
- ログアウト時のトークン削除で他メンバーのトークンを削除できないことの検証
<!-- /REVIEW_FOCUS -->

## チェックリスト

- [x] ローカルで動作確認済み(`sbt test` 全 641 件成功)
- [x] テストを追加・更新済み
- [ ] ドキュメントを更新済み(必要な場合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)